### PR TITLE
Remove the hardcoded strictSSL=false value.

### DIFF
--- a/lib/common-request.js
+++ b/lib/common-request.js
@@ -12,18 +12,19 @@ const request = require('request');
 module.exports = function doRequest (client, options) {
   return new Promise((resolve, reject) => {
     options = options || {};
+    const requestSettings = (client.settings && client.settings.request) ? client.settings.request : {};
     const clientConfig = privates.get(client).config;
 
     const baseOptions = {
       auth: {
         bearer: clientConfig.user.token || ''
       },
-      strictSSL: false, // Just for testing since self signed certs
       json: true
     };
 
-    // merge the 2 objects together, make the options be the thing that can override
-    const req = Object.assign({}, baseOptions, options);
+    // merge the 3 objects together, make the options be the thing that can override
+    // request settings will be request specific stuff that is overriden during the initial creation of the client
+    const req = Object.assign({}, baseOptions, options, requestSettings);
 
     request(req, (err, resp, body) => {
       if (err) {

--- a/lib/openshift-rest-client.js
+++ b/lib/openshift-rest-client.js
@@ -42,6 +42,8 @@ function openshiftClient (config, settings) {
     routes: routes,
     replicationcontrollers: replicationcontrollers
   }));
+
+  client.settings = settings;
   // A WeakMap reference to our private data
   // means that when all references to 'client' disappear
   // then the entry will be removed from the map

--- a/test/openshift-client-test.js
+++ b/test/openshift-client-test.js
@@ -25,3 +25,29 @@ test('openshift client tests', (t) => {
     t.end();
   });
 });
+
+test('openshift client settings test', (t) => {
+  // Need to stub the config loader for these tests
+  const stubbedConfigLoader = (client) => {
+    return Promise.resolve(client);
+  };
+
+  const openshiftRestClient = proxyquire('../lib/openshift-rest-client', {
+    './config-loader': stubbedConfigLoader
+  });
+
+  const settings = {
+    request: {
+      strictSSL: true
+    }
+  };
+
+  const osClient = openshiftRestClient(null, settings);
+
+  osClient.then((client) => {
+    t.ok(client.settings, 'client object should have a settings object');
+    console.log(client.settings);
+    t.ok(client.settings.request, 'client object should have a settings.request object');
+    t.end();
+  });
+});


### PR DESCRIPTION
there is now a settings object passed in during the initial creation of the client.  settings.request will be merged to the request options during requests

connects to #10