### PR TITLE
lib: reject failed requests with an Error

### DIFF
--- a/lib/common-request.js
+++ b/lib/common-request.js
@@ -47,6 +47,8 @@ module.exports = function doRequest (client, options) {
 
     request(req, (err, resp, body) => {
       if (err) {
+        const err = new Error(body);
+        err.statusCode = resp.statusCode;
         return reject(err);
       }
 


### PR DESCRIPTION
Instead of just rejecting the request with the response body, actually create an `Error`
object, setting the `.message` property to the response body, and `.statusCode` to the HTTP response code.

This is a supporting change for https://github.com/bucharest-gold/nodeshift/issues/98