### PR TITLE
Adding lots of resources & methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ docs/
 # Logs
 logs
 *.log
+.idea/
 npm-debug.log*
 
 # Runtime data

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Code:
     openshiftConfigLoader(settings).then((config) => {
       openshiftRestClient(config).then((client) => {
         // Use the client object to find a list of projects, for example
-        client.projects.find().then((projects) => {
+        client.projects.findAll().then((projects) => {
           console.log(projects);
         });
       });

--- a/lib/build-configs.js
+++ b/lib/build-configs.js
@@ -20,13 +20,29 @@
 
 const request = require('./common-request');
 const fs = require('fs');
-
 const privates = require('./private-map');
 
-// Finds a buildconfig on a namespace and build(?) name
-function find (client) {
-  return function find (buildConfigName) {
+function findAll (client) {
+  return function findAll (options = {}) {
     const clientConfig = privates.get(client).config;
+
+    const req = {
+      method: 'GET',
+      url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/buildconfigs`,
+      qs: options.qs
+    };
+
+    return request(client, req);
+  };
+}
+
+function find (client) {
+  return function find (buildConfigName, options = {}) {
+    const clientConfig = privates.get(client).config;
+
+    if (!buildConfigName) {
+      return Promise.reject(new Error('Build Config Name is required'));
+    }
 
     const req = {
       method: 'GET',
@@ -37,11 +53,8 @@ function find (client) {
   };
 }
 
-// Uploads a .tar file to become an image
-// options.dockerArchive is the location of the file
 function instantiateBinary (client) {
-  return function instantiateBinary (buildName, options) {
-    options = options || {};
+  return function instantiateBinary (buildName, options = {}) {
     const clientConfig = privates.get(client).config;
 
     const req = {
@@ -57,17 +70,36 @@ function instantiateBinary (client) {
   };
 }
 
-// Creates a buildconfig
-// Takes a BuildConfig JSON object, defined here: https://docs.openshift.com/online/rest_api/openshift_v1.html#v1-buildconfig
 function create (client) {
-  return function create (buidConfig, options) {
+  return function create (buildConfig, options = {}) {
     const clientConfig = privates.get(client).config;
 
     const req = {
       method: 'POST',
       url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/buildconfigs`,
       json: false,
-      body: JSON.stringify(buidConfig)
+      body: JSON.stringify(buildConfig)
+    };
+
+    return request(client, req).then((body) => {
+      return JSON.parse(body);
+    });
+  };
+}
+
+function update (client) {
+  return function create (buildConfigName, buildConfig, options = {}) {
+    const clientConfig = privates.get(client).config;
+
+    if (!buildConfigName) {
+      return Promise.reject(new Error('Build Config Name is required'));
+    }
+
+    const req = {
+      method: 'PUT',
+      json: false,
+      url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/buildconfigs/${buildConfigName}`,
+      body: JSON.stringify(buildConfig)
     };
 
     return request(client, req).then((body) => {
@@ -77,14 +109,12 @@ function create (client) {
 }
 
 function remove (client) {
-  return function remove (buildConfigName, options) {
-    options = options || {};
+  return function remove (buildConfigName, options = {}) {
+    const clientConfig = privates.get(client).config;
 
     if (!buildConfigName) {
       return Promise.reject(new Error('Build Config Name is required'));
     }
-
-    const clientConfig = privates.get(client).config;
 
     const req = {
       method: 'DELETE',
@@ -97,9 +127,26 @@ function remove (client) {
   };
 }
 
+function removeAll (client) {
+  return function removeAll (options = {}) {
+    const clientConfig = privates.get(client).config;
+
+    const req = {
+      method: 'DELETE',
+      url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/buildconfigs`,
+      qs: options.qs
+    };
+
+    return request(client, req);
+  };
+}
+
 module.exports = {
+  findAll: findAll,
   find: find,
   create: create,
+  update: update,
   instantiateBinary: instantiateBinary,
-  remove: remove
+  remove: remove,
+  removeAll: removeAll
 };

--- a/lib/builds.js
+++ b/lib/builds.js
@@ -19,25 +19,8 @@
  */
 
 const request = require('./common-request');
-
 const privates = require('./private-map');
 
-// Finds a buildconfig on a namespace and build(?) name
-function find (client) {
-  return function find (buildName) {
-    const clientConfig = privates.get(client).config;
-
-    const req = {
-      method: 'GET',
-      url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/builds/${buildName}`
-    };
-
-    return request(client, req);
-  };
-}
-
-// find all builds
-// Returns a BuildList object https://docs.openshift.com/container-platform/3.5/rest_api/openshift_v1.html#v1-buildlist
 function findAll (client) {
   return function findAll (options = {}) {
     const clientConfig = privates.get(client).config;
@@ -52,7 +35,61 @@ function findAll (client) {
   };
 }
 
-// remove build based on the buildname
+function find (client) {
+  return function find (buildName, options = {}) {
+    const clientConfig = privates.get(client).config;
+
+    if (!buildName) {
+      return Promise.reject(new Error('Build Name is required'));
+    }
+
+    const req = {
+      method: 'GET',
+      url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/builds/${buildName}`
+    };
+
+    return request(client, req);
+  };
+}
+
+function create (client) {
+  return function create (build, options = {}) {
+    const clientConfig = privates.get(client).config;
+
+    const req = {
+      method: 'POST',
+      url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/builds`,
+      json: false,
+      body: JSON.stringify(build)
+    };
+
+    return request(client, req).then((body) => {
+      return JSON.parse(body);
+    });
+  };
+}
+
+function update (client) {
+  return function create (buildName, build, options = {}) {
+    const clientConfig = privates.get(client).config;
+
+    if (!buildName) {
+      return Promise.reject(new Error('Build Name is required'));
+    }
+
+    const req = {
+      method: 'PUT',
+      json: false,
+      url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/builds/${buildName}`,
+      body: JSON.stringify(build)
+    };
+
+    return request(client, req).then((body) => {
+      return JSON.parse(body);
+    });
+  };
+}
+
 function remove (client) {
   return function remove (buildName, options = {}) {
     const clientConfig = privates.get(client).config;
@@ -72,8 +109,25 @@ function remove (client) {
   };
 }
 
+function removeAll (client) {
+  return function removeAll (options = {}) {
+    const clientConfig = privates.get(client).config;
+
+    const req = {
+      method: 'DELETE',
+      url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/builds`,
+      qs: options.qs
+    };
+
+    return request(client, req);
+  };
+}
+
 module.exports = {
-  find: find,
   findAll: findAll,
-  remove: remove
+  find: find,
+  create: create,
+  update: update,
+  remove: remove,
+  removeAll: removeAll
 };

--- a/lib/cluster-role-bindings.js
+++ b/lib/cluster-role-bindings.js
@@ -1,0 +1,93 @@
+'use strict';
+
+/*
+ *
+ *  Copyright 2016-2017 Red Hat, Inc, and individual contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+const request = require('./common-request');
+
+function findAll (client) {
+  return function findAll (options) {
+    options = options || {}
+    const req = {
+      method: 'GET',
+      url: `${client.apiUrl}/clusterrolebindings`,
+      qs: options.qs
+    };
+
+    return request(client, req);
+  };
+}
+
+function find (client) {
+  return function find (clusterRoleBindingName, options) {
+    options = options || {};
+    if (!clusterRoleBindingName) {
+      return Promise.reject(new Error('Cluster Role Binding Name is required'));
+    }
+
+    const req = {
+      method: 'GET',
+      url: `${client.apiUrl}/clusterrolebindings/${clusterRoleBindingName}`
+    };
+
+    return request(client, req);
+  };
+}
+
+function create (client) {
+  return function create (clusterRoleBinding, options) {
+    options = options || {};
+
+    const req = {
+      method: 'POST',
+      json: false,
+      url: `${client.apiUrl}/clusterrolebindings`,
+      body: JSON.stringify(clusterRoleBinding)
+    };
+
+    return request(client, req).then((body) => {
+      return JSON.parse(body);
+    });
+  };
+}
+
+function remove (client) {
+  return function remove (clusterRoleBindingName, options) {
+    options = options || {};
+
+    if (!clusterRoleBindingName) {
+      return Promise.reject(new Error('Cluster Role Binding Name is required'));
+    }
+
+    const req = {
+      method: 'DELETE',
+      url: `${client.apiUrl}/clusterrolebindings/${clusterRoleBindingName}`,
+      qs: options.qs,
+      body: options.body
+    };
+
+    return request(client, req);
+  };
+}
+
+module.exports = {
+  findAll: findAll,
+  find: find,
+  create: create,
+  remove: remove
+};

--- a/lib/cluster-role-bindings.js
+++ b/lib/cluster-role-bindings.js
@@ -21,8 +21,7 @@
 const request = require('./common-request');
 
 function findAll (client) {
-  return function findAll (options) {
-    options = options || {}
+  return function findAll (options = {}) {
     const req = {
       method: 'GET',
       url: `${client.apiUrl}/clusterrolebindings`,
@@ -34,8 +33,7 @@ function findAll (client) {
 }
 
 function find (client) {
-  return function find (clusterRoleBindingName, options) {
-    options = options || {};
+  return function find (clusterRoleBindingName, options = {}) {
     if (!clusterRoleBindingName) {
       return Promise.reject(new Error('Cluster Role Binding Name is required'));
     }
@@ -50,9 +48,7 @@ function find (client) {
 }
 
 function create (client) {
-  return function create (clusterRoleBinding, options) {
-    options = options || {};
-
+  return function create (clusterRoleBinding, options = {}) {
     const req = {
       method: 'POST',
       json: false,
@@ -67,9 +63,7 @@ function create (client) {
 }
 
 function remove (client) {
-  return function remove (clusterRoleBindingName, options) {
-    options = options || {};
-
+  return function remove (clusterRoleBindingName, options = {}) {
     if (!clusterRoleBindingName) {
       return Promise.reject(new Error('Cluster Role Binding Name is required'));
     }

--- a/lib/configmaps.js
+++ b/lib/configmaps.js
@@ -40,7 +40,7 @@ function find (client) {
     const clientConfig = privates.get(client).config;
 
     if (!configMapName) {
-      return Promise.reject(new Error('ConfigMap Name is required'));
+      return Promise.reject(new Error('Config Map Name is required'));
     }
 
     const req = {
@@ -74,7 +74,7 @@ function update (client) {
     const clientConfig = privates.get(client).config;
 
     if (!configMapName) {
-      return Promise.reject(new Error('ConfigMap Name is required'));
+      return Promise.reject(new Error('Config Map Name is required'));
     }
 
     const req = {
@@ -95,7 +95,7 @@ function remove (client) {
     const clientConfig = privates.get(client).config;
 
     if (!configMapName) {
-      return Promise.reject(new Error('ConfigMap Name is required'));
+      return Promise.reject(new Error('Config Map Name is required'));
     }
 
     const req = {

--- a/lib/configmaps.js
+++ b/lib/configmaps.js
@@ -18,22 +18,104 @@
  *
  */
 
-const privates = require('./private-map');
 const request = require('./common-request');
+const privates = require('./private-map');
 
-// Finds configMap based on a namespace and build(?) name
+function findAll (client) {
+  return function findAll (options = {}) {
+    const clientConfig = privates.get(client).config;
+
+    const req = {
+      method: 'GET',
+      url: `${client.kubeUrl}/namespaces/${clientConfig.context.namespace}/configmaps`,
+      qs: options.qs
+    };
+
+    return request(client, req);
+  };
+}
+
 function find (client) {
   return function find (configMapName, options = {}) {
+    const clientConfig = privates.get(client).config;
+
     if (!configMapName) {
       return Promise.reject(new Error('ConfigMap Name is required'));
     }
 
-    const clientConfig = privates.get(client).config;
-
-    // Using api here instead of oapi
     const req = {
       method: 'GET',
+      url: `${client.kubeUrl}/namespaces/${clientConfig.context.namespace}/configmaps/${configMapName}`
+    };
+
+    return request(client, req);
+  };
+}
+
+function create (client) {
+  return function create (configMap, options = {}) {
+    const clientConfig = privates.get(client).config;
+
+    const req = {
+      method: 'POST',
+      url: `${client.kubeUrl}/namespaces/${clientConfig.context.namespace}/configmaps`,
+      json: false,
+      body: JSON.stringify(configMap)
+    };
+
+    return request(client, req).then((body) => {
+      return JSON.parse(body);
+    });
+  };
+}
+
+function update (client) {
+  return function create (configMapName, configMap, options = {}) {
+    const clientConfig = privates.get(client).config;
+
+    if (!configMapName) {
+      return Promise.reject(new Error('ConfigMap Name is required'));
+    }
+
+    const req = {
+      method: 'PUT',
+      json: false,
       url: `${client.kubeUrl}/namespaces/${clientConfig.context.namespace}/configmaps/${configMapName}`,
+      body: JSON.stringify(configMap)
+    };
+
+    return request(client, req).then((body) => {
+      return JSON.parse(body);
+    });
+  };
+}
+
+function remove (client) {
+  return function remove (configMapName, options = {}) {
+    const clientConfig = privates.get(client).config;
+
+    if (!configMapName) {
+      return Promise.reject(new Error('ConfigMap Name is required'));
+    }
+
+    const req = {
+      method: 'DELETE',
+      url: `${client.kubeUrl}/namespaces/${clientConfig.context.namespace}/configmaps/${configMapName}`,
+      body: options.body,
+      qs: options.qs
+    };
+
+    return request(client, req);
+  };
+}
+
+function removeAll (client) {
+  return function removeAll (options = {}) {
+    const clientConfig = privates.get(client).config;
+
+    const req = {
+      method: 'DELETE',
+      url: `${client.kubeUrl}/namespaces/${clientConfig.context.namespace}/configmaps`,
       qs: options.qs
     };
 
@@ -42,5 +124,10 @@ function find (client) {
 }
 
 module.exports = {
-  find: find
+  findAll: findAll,
+  find: find,
+  create: create,
+  update: update,
+  remove: remove,
+  removeAll: removeAll
 };

--- a/lib/deployment-config.js
+++ b/lib/deployment-config.js
@@ -22,8 +22,7 @@ const request = require('./common-request');
 const privates = require('./private-map');
 
 function findAll (client) {
-  return function findAll (options) {
-    options = options || {};
+  return function findAll (options = {}) {
     const clientConfig = privates.get(client).config;
 
     const req = {
@@ -37,12 +36,12 @@ function findAll (client) {
 }
 
 function find (client) {
-  return function find (deploymentConfigName, options) {
-    options = options || {};
+  return function find (deploymentConfigName, options = {}) {
+    const clientConfig = privates.get(client).config;
+
     if (!deploymentConfigName) {
       return Promise.reject(new Error('Deployment Config Name is required'));
     }
-    const clientConfig = privates.get(client).config;
 
     const req = {
       method: 'GET',
@@ -54,14 +53,34 @@ function find (client) {
 }
 
 function create (client) {
-  return function create (deploymentConfig, options) {
-    options = options || {};
+  return function create (deploymentConfig, options = {}) {
     const clientConfig = privates.get(client).config;
 
     const req = {
       method: 'POST',
-      json: false,
       url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/deploymentconfigs`,
+      json: false,
+      body: JSON.stringify(deploymentConfig)
+    };
+
+    return request(client, req).then((body) => {
+      return JSON.parse(body);
+    });
+  };
+}
+
+function update (client) {
+  return function create (deploymentConfigName, deploymentConfig, options = {}) {
+    const clientConfig = privates.get(client).config;
+
+    if (!deploymentConfigName) {
+      return Promise.reject(new Error('Deployment Config Name is required'));
+    }
+
+    const req = {
+      method: 'PUT',
+      json: false,
+      url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/deploymentconfigs/${deploymentConfigName}`,
       body: JSON.stringify(deploymentConfig)
     };
 
@@ -72,20 +91,18 @@ function create (client) {
 }
 
 function remove (client) {
-  return function remove (deploymentConfigName, options) {
-    options = options || {};
+  return function remove (deploymentConfigName, options = {}) {
+    const clientConfig = privates.get(client).config;
 
     if (!deploymentConfigName) {
       return Promise.reject(new Error('Deployment Config Name is required'));
     }
 
-    const clientConfig = privates.get(client).config;
-
     const req = {
       method: 'DELETE',
       url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/deploymentconfigs/${deploymentConfigName}`,
-      qs: options.qs,
-      body: options.body
+      body: options.body,
+      qs: options.qs
     };
 
     return request(client, req);
@@ -93,8 +110,7 @@ function remove (client) {
 }
 
 function removeAll (client) {
-  return function removeAll (options) {
-    options = options || {};
+  return function removeAll (options = {}) {
     const clientConfig = privates.get(client).config;
 
     const req = {
@@ -111,6 +127,7 @@ module.exports = {
   findAll: findAll,
   find: find,
   create: create,
+  update: update,
   remove: remove,
   removeAll: removeAll
 };

--- a/lib/deployment-config.js
+++ b/lib/deployment-config.js
@@ -18,12 +18,30 @@
  *
  */
 
-const privates = require('./private-map');
 const request = require('./common-request');
+const privates = require('./private-map');
 
-// Finds an image stream based on a namespace and build(?) name
+function findAll (client) {
+  return function findAll (options) {
+    options = options || {};
+    const clientConfig = privates.get(client).config;
+
+    const req = {
+      method: 'GET',
+      url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/deploymentconfigs`,
+      qs: options.qs
+    };
+
+    return request(client, req);
+  };
+}
+
 function find (client) {
-  return function find (deploymentConfigName) {
+  return function find (deploymentConfigName, options) {
+    options = options || {};
+    if (!deploymentConfigName) {
+      return Promise.reject(new Error('Deployment Config Name is required'));
+    }
     const clientConfig = privates.get(client).config;
 
     const req = {
@@ -74,8 +92,25 @@ function remove (client) {
   };
 }
 
+function removeAll (client) {
+  return function removeAll (options) {
+    options = options || {};
+    const clientConfig = privates.get(client).config;
+
+    const req = {
+      method: 'DELETE',
+      url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/deploymentconfigs`,
+      qs: options.qs
+    };
+
+    return request(client, req);
+  };
+}
+
 module.exports = {
+  findAll: findAll,
   find: find,
   create: create,
-  remove: remove
+  remove: remove,
+  removeAll: removeAll
 };

--- a/lib/groups.js
+++ b/lib/groups.js
@@ -21,8 +21,7 @@
 const request = require('./common-request');
 
 function findAll (client) {
-  return function findAll (options) {
-    options = options || {}
+  return function findAll (options = {}) {
     const req = {
       method: 'GET',
       url: `${client.apiUrl}/groups`,
@@ -34,8 +33,7 @@ function findAll (client) {
 }
 
 function find (client) {
-  return function find (groupName, options) {
-    options = options || {};
+  return function find (groupName, options = {}) {
     if (!groupName) {
       return Promise.reject(new Error('Group Name is required'));
     }
@@ -50,9 +48,7 @@ function find (client) {
 }
 
 function create (client) {
-  return function create (group, options) {
-    options = options || {};
-
+  return function create (group, options = {}) {
     const req = {
       method: 'POST',
       json: false,
@@ -66,10 +62,27 @@ function create (client) {
   };
 }
 
-function remove (client) {
-  return function remove (groupName, options) {
-    options = options || {};
+function update (client) {
+  return function create (groupName, group, options = {}) {
+    if (!groupName) {
+      return Promise.reject(new Error('Group Name is required'));
+    }
 
+    const req = {
+      method: 'PUT',
+      json: false,
+      url: `${client.apiUrl}/groups/${groupName}`,
+      body: JSON.stringify(group)
+    };
+
+    return request(client, req).then((body) => {
+      return JSON.parse(body);
+    });
+  };
+}
+
+function remove (client) {
+  return function remove (groupName, options = {}) {
     if (!groupName) {
       return Promise.reject(new Error('Group Name is required'));
     }
@@ -86,9 +99,7 @@ function remove (client) {
 }
 
 function removeAll (client) {
-  return function removeAll (options) {
-    options = options || {};
-
+  return function removeAll (options = {}) {
     const req = {
       method: 'DELETE',
       url: `${client.apiUrl}/groups`,
@@ -103,6 +114,7 @@ module.exports = {
   findAll: findAll,
   find: find,
   create: create,
+  update: update,
   remove: remove,
   removeAll: removeAll
 };

--- a/lib/groups.js
+++ b/lib/groups.js
@@ -1,0 +1,108 @@
+'use strict';
+
+/*
+ *
+ *  Copyright 2016-2017 Red Hat, Inc, and individual contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+const request = require('./common-request');
+
+function findAll (client) {
+  return function findAll (options) {
+    options = options || {}
+    const req = {
+      method: 'GET',
+      url: `${client.apiUrl}/groups`,
+      qs: options.qs
+    };
+
+    return request(client, req);
+  };
+}
+
+function find (client) {
+  return function find (groupName, options) {
+    options = options || {};
+    if (!groupName) {
+      return Promise.reject(new Error('Group Name is required'));
+    }
+
+    const req = {
+      method: 'GET',
+      url: `${client.apiUrl}/groups/${groupName}`
+    };
+
+    return request(client, req);
+  };
+}
+
+function create (client) {
+  return function create (group, options) {
+    options = options || {};
+
+    const req = {
+      method: 'POST',
+      json: false,
+      url: `${client.apiUrl}/groups`,
+      body: JSON.stringify(group)
+    };
+
+    return request(client, req).then((body) => {
+      return JSON.parse(body);
+    });
+  };
+}
+
+function remove (client) {
+  return function remove (groupName, options) {
+    options = options || {};
+
+    if (!groupName) {
+      return Promise.reject(new Error('Group Name is required'));
+    }
+
+    const req = {
+      method: 'DELETE',
+      url: `${client.apiUrl}/groups/${groupName}`,
+      qs: options.qs,
+      body: options.body
+    };
+
+    return request(client, req);
+  };
+}
+
+function removeAll (client) {
+  return function removeAll (options) {
+    options = options || {};
+
+    const req = {
+      method: 'DELETE',
+      url: `${client.apiUrl}/groups`,
+      qs: options.qs
+    };
+
+    return request(client, req);
+  };
+}
+
+module.exports = {
+  findAll: findAll,
+  find: find,
+  create: create,
+  remove: remove,
+  removeAll: removeAll
+};

--- a/lib/imagestreams.js
+++ b/lib/imagestreams.js
@@ -18,13 +18,30 @@
  *
  */
 
-const privates = require('./private-map');
 const request = require('./common-request');
+const privates = require('./private-map');
 
-// Finds an image stream based on a namespace and build(?) name
-function find (client) {
-  return function find (imageStreamName) {
+function findAll (client) {
+  return function findAll (options = {}) {
     const clientConfig = privates.get(client).config;
+
+    const req = {
+      method: 'GET',
+      url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/imagestreams`,
+      qs: options.qs
+    };
+
+    return request(client, req);
+  };
+}
+
+function find (client) {
+  return function find (imageStreamName, options = {}) {
+    const clientConfig = privates.get(client).config;
+
+    if (!imageStreamName) {
+      return Promise.reject(new Error('Image Stream Name is required'));
+    }
 
     const req = {
       method: 'GET',
@@ -36,15 +53,35 @@ function find (client) {
 }
 
 function create (client) {
-  return function create (imageStreamConfig, options) {
-    options = options || {};
+  return function create (imageStream, options = {}) {
     const clientConfig = privates.get(client).config;
 
     const req = {
       method: 'POST',
       url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/imagestreams`,
-      body: JSON.stringify(imageStreamConfig),
-      json: false
+      json: false,
+      body: JSON.stringify(imageStream)
+    };
+
+    return request(client, req).then((body) => {
+      return JSON.parse(body);
+    });
+  };
+}
+
+function update (client) {
+  return function create (imageStreamName, imageStream, options = {}) {
+    const clientConfig = privates.get(client).config;
+
+    if (!imageStreamName) {
+      return Promise.reject(new Error('Image Stream Name is required'));
+    }
+
+    const req = {
+      method: 'PUT',
+      json: false,
+      url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/imagestreams/${imageStreamName}`,
+      body: JSON.stringify(imageStream)
     };
 
     return request(client, req).then((body) => {
@@ -54,14 +91,12 @@ function create (client) {
 }
 
 function remove (client) {
-  return function remove (imageStreamName, options) {
-    options = options || {};
+  return function remove (imageStreamName, options = {}) {
+    const clientConfig = privates.get(client).config;
 
     if (!imageStreamName) {
       return Promise.reject(new Error('Image Stream Name is required'));
     }
-
-    const clientConfig = privates.get(client).config;
 
     const req = {
       method: 'DELETE',
@@ -74,8 +109,25 @@ function remove (client) {
   };
 }
 
+function removeAll (client) {
+  return function removeAll (options = {}) {
+    const clientConfig = privates.get(client).config;
+
+    const req = {
+      method: 'DELETE',
+      url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/imagestreams`,
+      qs: options.qs
+    };
+
+    return request(client, req);
+  };
+}
+
 module.exports = {
+  findAll: findAll,
   find: find,
   create: create,
-  remove: remove
+  update: update,
+  remove: remove,
+  removeAll: removeAll
 };

--- a/lib/openshift-rest-client.js
+++ b/lib/openshift-rest-client.js
@@ -23,7 +23,7 @@ const loadConfig = require('./config-loader');
 
 const buildconfigs = require('./build-configs');
 const builds = require('./builds');
-const clusterrolebindings = require('./cluster-role-bindings')
+const clusterrolebindings = require('./cluster-role-bindings');
 const configMaps = require('./configmaps');
 const deploymentconfigs = require('./deployment-config');
 const groups = require('./groups');
@@ -32,7 +32,7 @@ const pods = require('./pods');
 const projectrequests = require('./projectrequests');
 const projects = require('./projects');
 const replicationcontrollers = require('./replication-controllers');
-const rolebindings = require('./role-bindings')
+const rolebindings = require('./role-bindings');
 const routes = require('./routes');
 const secrets = require('./secrets');
 const services = require('./services');

--- a/lib/openshift-rest-client.js
+++ b/lib/openshift-rest-client.js
@@ -23,6 +23,7 @@ const loadConfig = require('./config-loader');
 
 const buildconfigs = require('./build-configs');
 const builds = require('./builds');
+const clusterrolebindings = require('./cluster-role-bindings')
 const configMaps = require('./configmaps');
 const deploymentconfigs = require('./deployment-config');
 const groups = require('./groups');
@@ -31,6 +32,7 @@ const pods = require('./pods');
 const projectrequests = require('./projectrequests');
 const projects = require('./projects');
 const replicationcontrollers = require('./replication-controllers');
+const rolebindings = require('./role-bindings')
 const routes = require('./routes');
 const secrets = require('./secrets');
 const services = require('./services');
@@ -58,6 +60,7 @@ function openshiftClient (config, settings) {
   Object.assign(client, bindModule(client, {
     buildconfigs: buildconfigs,
     builds: builds,
+    clusterrolebindings: clusterrolebindings,
     configmaps: configMaps,
     deploymentconfigs: deploymentconfigs,
     groups: groups,
@@ -66,6 +69,7 @@ function openshiftClient (config, settings) {
     projectrequests: projectrequests,
     projects: projects,
     replicationcontrollers: replicationcontrollers,
+    rolebindings: rolebindings,
     routes: routes,
     secrets: secrets,
     services: services

--- a/lib/openshift-rest-client.js
+++ b/lib/openshift-rest-client.js
@@ -21,16 +21,19 @@
 const privates = require('./private-map');
 const loadConfig = require('./config-loader');
 
-const projects = require('./projects');
-const imagestreams = require('./imagestreams');
 const buildconfigs = require('./build-configs');
 const builds = require('./builds');
-const services = require('./services');
-const deploymentconfigs = require('./deployment-config');
-const routes = require('./routes');
-const replicationcontrollers = require('./replication-controllers');
-const secrets = require('./secrets');
 const configMaps = require('./configmaps');
+const deploymentconfigs = require('./deployment-config');
+const groups = require('./groups');
+const imagestreams = require('./imagestreams');
+const pods = require('./pods');
+const projectrequests = require('./projectrequests');
+const projects = require('./projects');
+const replicationcontrollers = require('./replication-controllers');
+const routes = require('./routes');
+const secrets = require('./secrets');
+const services = require('./services');
 
 function bindModule (client, input) {
   if (typeof input === 'object') {
@@ -53,16 +56,19 @@ function openshiftClient (config, settings) {
   const client = {};
 
   Object.assign(client, bindModule(client, {
-    projects: projects,
     buildconfigs: buildconfigs,
     builds: builds,
-    imagestreams: imagestreams,
-    services: services,
+    configmaps: configMaps,
     deploymentconfigs: deploymentconfigs,
-    routes: routes,
+    groups: groups,
+    imagestreams: imagestreams,
+    pods: pods,
+    projectrequests: projectrequests,
+    projects: projects,
     replicationcontrollers: replicationcontrollers,
+    routes: routes,
     secrets: secrets,
-    configmaps: configMaps
+    services: services
   }));
 
   client.settings = settings;

--- a/lib/pods.js
+++ b/lib/pods.js
@@ -22,8 +22,7 @@ const request = require('./common-request');
 const privates = require('./private-map');
 
 function findAll (client) {
-  return function findAll (options) {
-    options = options || {};
+  return function findAll (options = {}) {
     const clientConfig = privates.get(client).config;
 
     const req = {
@@ -37,12 +36,12 @@ function findAll (client) {
 }
 
 function find (client) {
-  return function find (podName, options) {
-    options = options || {};
+  return function find (podName, options = {}) {
+    const clientConfig = privates.get(client).config;
+
     if (!podName) {
       return Promise.reject(new Error('Pod Name is required'));
     }
-    const clientConfig = privates.get(client).config;
 
     const req = {
       method: 'GET',
@@ -53,15 +52,51 @@ function find (client) {
   };
 }
 
-function remove (client) {
-  return function remove (podName, options) {
-    options = options || {};
+function create (client) {
+  return function create (pod, options = {}) {
+    const clientConfig = privates.get(client).config;
+
+    const req = {
+      method: 'POST',
+      url: `${client.kubeUrl}/namespaces/${clientConfig.context.namespace}/pods`,
+      json: false,
+      body: JSON.stringify(pod)
+    };
+
+    return request(client, req).then((body) => {
+      return JSON.parse(body);
+    });
+  };
+}
+
+function update (client) {
+  return function create (podName, pod, options = {}) {
+    const clientConfig = privates.get(client).config;
 
     if (!podName) {
       return Promise.reject(new Error('Pod Name is required'));
     }
 
+    const req = {
+      method: 'PUT',
+      json: false,
+      url: `${client.kubeUrl}/namespaces/${clientConfig.context.namespace}/pods/${podName}`,
+      body: JSON.stringify(pod)
+    };
+
+    return request(client, req).then((body) => {
+      return JSON.parse(body);
+    });
+  };
+}
+
+function remove (client) {
+  return function remove (podName, options = {}) {
     const clientConfig = privates.get(client).config;
+
+    if (!podName) {
+      return Promise.reject(new Error('Pod Name is required'));
+    }
 
     const req = {
       method: 'DELETE',
@@ -75,9 +110,7 @@ function remove (client) {
 }
 
 function removeAll (client) {
-  return function removeAll (options) {
-    options = options || {};
-
+  return function removeAll (options = {}) {
     const clientConfig = privates.get(client).config;
 
     const req = {
@@ -93,6 +126,8 @@ function removeAll (client) {
 module.exports = {
   findAll: findAll,
   find: find,
+  create: create,
+  update: update,
   remove: remove,
   removeAll: removeAll
 };

--- a/lib/pods.js
+++ b/lib/pods.js
@@ -1,0 +1,98 @@
+'use strict';
+
+/*
+ *
+ *  Copyright 2016-2017 Red Hat, Inc, and individual contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+const request = require('./common-request');
+const privates = require('./private-map');
+
+function findAll (client) {
+  return function findAll (options) {
+    options = options || {};
+    const clientConfig = privates.get(client).config;
+
+    const req = {
+      method: 'GET',
+      url: `${client.kubeUrl}/namespaces/${clientConfig.context.namespace}/pods`,
+      qs: options.qs
+    };
+
+    return request(client, req);
+  };
+}
+
+function find (client) {
+  return function find (podName, options) {
+    options = options || {};
+    if (!podName) {
+      return Promise.reject(new Error('Pod Name is required'));
+    }
+    const clientConfig = privates.get(client).config;
+
+    const req = {
+      method: 'GET',
+      url: `${client.kubeUrl}/namespaces/${clientConfig.context.namespace}/pods/${podName}`
+    };
+
+    return request(client, req);
+  };
+}
+
+function remove (client) {
+  return function remove (podName, options) {
+    options = options || {};
+
+    if (!podName) {
+      return Promise.reject(new Error('Pod Name is required'));
+    }
+
+    const clientConfig = privates.get(client).config;
+
+    const req = {
+      method: 'DELETE',
+      url: `${client.kubeUrl}/namespaces/${clientConfig.context.namespace}/pods/${podName}`,
+      body: options.body,
+      qs: options.qs
+    };
+
+    return request(client, req);
+  };
+}
+
+function removeAll (client) {
+  return function removeAll (options) {
+    options = options || {};
+
+    const clientConfig = privates.get(client).config;
+
+    const req = {
+      method: 'DELETE',
+      url: `${client.kubeUrl}/namespaces/${clientConfig.context.namespace}/pods`,
+      qs: options.qs
+    };
+
+    return request(client, req);
+  };
+}
+
+module.exports = {
+  findAll: findAll,
+  find: find,
+  remove: remove,
+  removeAll: removeAll
+};

--- a/lib/projectrequests.js
+++ b/lib/projectrequests.js
@@ -20,9 +20,7 @@
 const request = require('./common-request');
 
 function findAll (client) {
-  return function find (options) {
-    options = options || {};
-
+  return function find (options = {}) {
     const req = {
       method: 'GET',
       qs: options.qs,
@@ -34,7 +32,7 @@ function findAll (client) {
 }
 
 function create (client) {
-  return function create (projectrequest) {
+  return function create (projectrequest, options = {}) {
     const req = {
       method: 'POST',
       json: false,

--- a/lib/projectrequests.js
+++ b/lib/projectrequests.js
@@ -1,0 +1,54 @@
+'use strict';
+/*
+ *
+ *  Copyright 2016-2017 Red Hat, Inc, and individual contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+const request = require('./common-request');
+
+function findAll (client) {
+  return function find (options) {
+    options = options || {};
+
+    const req = {
+      method: 'GET',
+      qs: options.qs,
+      url: `${client.apiUrl}/projectrequests`
+    };
+
+    return request(client, req);
+  };
+}
+
+function create (client) {
+  return function create (projectrequest) {
+    const req = {
+      method: 'POST',
+      json: false,
+      url: `${client.apiUrl}/projectrequests`,
+      body: JSON.stringify(projectrequest)
+    };
+
+    return request(client, req).then((body) => {
+      return JSON.parse(body);
+    });
+  };
+}
+
+module.exports = {
+  findAll: findAll,
+  create: create
+};

--- a/lib/projects.js
+++ b/lib/projects.js
@@ -1,4 +1,5 @@
 'use strict';
+
 /*
  *
  *  Copyright 2016-2017 Red Hat, Inc, and individual contributors.
@@ -20,13 +21,11 @@
 const request = require('./common-request');
 
 function findAll (client) {
-  return function findAll (options) {
-    options = options || {};
-
+  return function findAll (options = {}) {
     const req = {
       method: 'GET',
-      qs: options.qs,
-      url: `${client.apiUrl}/projects`
+      url: `${client.apiUrl}/projects`,
+      qs: options.qs
     };
 
     return request(client, req);
@@ -34,8 +33,7 @@ function findAll (client) {
 }
 
 function find (client) {
-  return function find (projectName, options) {
-    options = options || {};
+  return function find (projectName, options = {}) {
     if (!projectName) {
       return Promise.reject(new Error('Project Name is required'));
     }
@@ -49,15 +47,63 @@ function find (client) {
   };
 }
 
+function create (client) {
+  return function create (project, options = {}) {
+    const req = {
+      method: 'POST',
+      json: false,
+      url: `${client.apiUrl}/projects`,
+      body: JSON.stringify(project)
+    };
+
+    return request(client, req).then((body) => {
+      return JSON.parse(body);
+    });
+  };
+}
+
+function update (client) {
+  return function create (projectName, project, options = {}) {
+    if (!projectName) {
+      return Promise.reject(new Error('Project Name is required'));
+    }
+
+    const req = {
+      method: 'PUT',
+      json: false,
+      url: `${client.apiUrl}/projects/${projectName}`,
+      body: JSON.stringify(project)
+    };
+
+    return request(client, req).then((body) => {
+      return JSON.parse(body);
+    });
+  };
+}
+
 function remove (client) {
-  return function remove (projectName) {
+  return function remove (projectName, options = {}) {
     if (!projectName) {
       return Promise.reject(new Error('Project Name is required'));
     }
 
     const req = {
       method: 'DELETE',
-      url: `${client.apiUrl}/projects/${projectName}`
+      url: `${client.apiUrl}/projects/${projectName}`,
+      qs: options.qs,
+      body: options.body
+    };
+
+    return request(client, req);
+  };
+}
+
+function removeAll (client) {
+  return function removeAll (options = {}) {
+    const req = {
+      method: 'DELETE',
+      url: `${client.apiUrl}/projects`,
+      qs: options.qs
     };
 
     return request(client, req);
@@ -67,5 +113,8 @@ function remove (client) {
 module.exports = {
   findAll: findAll,
   find: find,
-  remove: remove
+  create: create,
+  update: update,
+  remove: remove,
+  removeAll: removeAll
 };

--- a/lib/projects.js
+++ b/lib/projects.js
@@ -19,17 +19,53 @@
 
 const request = require('./common-request');
 
-module.exports = {
-  find: find
-};
+function findAll (client) {
+  return function findAll (options) {
+    options = options || {};
 
-function find (client) {
-  return function find () {
     const req = {
       method: 'GET',
+      qs: options.qs,
       url: `${client.apiUrl}/projects`
     };
 
     return request(client, req);
   };
 }
+
+function find (client) {
+  return function find (projectName, options) {
+    options = options || {};
+    if (!projectName) {
+      return Promise.reject(new Error('Project Name is required'));
+    }
+
+    const req = {
+      method: 'GET',
+      url: `${client.apiUrl}/projects/${projectName}`
+    };
+
+    return request(client, req);
+  };
+}
+
+function remove (client) {
+  return function remove (projectName) {
+    if (!projectName) {
+      return Promise.reject(new Error('Project Name is required'));
+    }
+
+    const req = {
+      method: 'DELETE',
+      url: `${client.apiUrl}/projects/${projectName}`
+    };
+
+    return request(client, req);
+  };
+}
+
+module.exports = {
+  findAll: findAll,
+  find: find,
+  remove: remove
+};

--- a/lib/replication-controllers.js
+++ b/lib/replication-controllers.js
@@ -21,10 +21,8 @@
 const request = require('./common-request');
 const privates = require('./private-map');
 
-// find a list of replication controllers
 function findAll (client) {
-  return function findAll (options) {
-    options = options || {};
+  return function findAll (options = {}) {
     const clientConfig = privates.get(client).config;
 
     const req = {
@@ -37,15 +35,13 @@ function findAll (client) {
   };
 }
 
-// find just 1 replication controller
-// This could probably combined into 1 method with the above finfAll
 function find (client) {
-  return function find (replicationControllerName, options) {
-    options = options || {};
+  return function find (replicationControllerName, options = {}) {
+    const clientConfig = privates.get(client).config;
+
     if (!replicationControllerName) {
       return Promise.reject(new Error('Replication Controller Name is required'));
     }
-    const clientConfig = privates.get(client).config;
 
     const req = {
       method: 'GET',
@@ -56,15 +52,51 @@ function find (client) {
   };
 }
 
-function remove (client) {
-  return function remove (replicationControllerName, options) {
-    options = options || {};
+function create (client) {
+  return function create (replicationController, options = {}) {
+    const clientConfig = privates.get(client).config;
+
+    const req = {
+      method: 'POST',
+      url: `${client.kubeUrl}/namespaces/${clientConfig.context.namespace}/replicationcontrollers`,
+      json: false,
+      body: JSON.stringify(replicationController)
+    };
+
+    return request(client, req).then((body) => {
+      return JSON.parse(body);
+    });
+  };
+}
+
+function update (client) {
+  return function create (replicationControllerName, replicationController, options = {}) {
+    const clientConfig = privates.get(client).config;
 
     if (!replicationControllerName) {
       return Promise.reject(new Error('Replication Controller Name is required'));
     }
 
+    const req = {
+      method: 'PUT',
+      json: false,
+      url: `${client.kubeUrl}/namespaces/${clientConfig.context.namespace}/replicationcontrollers/${replicationControllerName}`,
+      body: JSON.stringify(replicationController)
+    };
+
+    return request(client, req).then((body) => {
+      return JSON.parse(body);
+    });
+  };
+}
+
+function remove (client) {
+  return function remove (replicationControllerName, options = {}) {
     const clientConfig = privates.get(client).config;
+
+    if (!replicationControllerName) {
+      return Promise.reject(new Error('Replication Controller Name is required'));
+    }
 
     const req = {
       method: 'DELETE',
@@ -78,9 +110,7 @@ function remove (client) {
 }
 
 function removeAll (client) {
-  return function removeAll (options) {
-    options = options || {};
-
+  return function removeAll (options = {}) {
     const clientConfig = privates.get(client).config;
 
     const req = {
@@ -96,6 +126,8 @@ function removeAll (client) {
 module.exports = {
   findAll: findAll,
   find: find,
+  create: create,
+  update: update,
   remove: remove,
   removeAll: removeAll
 };

--- a/lib/role-bindings.js
+++ b/lib/role-bindings.js
@@ -1,0 +1,100 @@
+'use strict';
+
+/*
+ *
+ *  Copyright 2016-2017 Red Hat, Inc, and individual contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+const request = require('./common-request');
+const privates = require('./private-map');
+
+function findAll (client) {
+  return function findAll (options) {
+    options = options || {};
+    const clientConfig = privates.get(client).config;
+
+    const req = {
+      method: 'GET',
+      url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/rolebindings`,
+      qs: options.qs
+    };
+
+    return request(client, req);
+  };
+}
+
+function find (client) {
+  return function find (roleBindingName, options) {
+    options = options || {};
+    if (!roleBindingName) {
+      return Promise.reject(new Error('Role Binding Name is required'));
+    }
+    const clientConfig = privates.get(client).config;
+
+    const req = {
+      method: 'GET',
+      url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/rolebindings/${roleBindingName}`
+    };
+
+    return request(client, req);
+  };
+}
+
+function create (client) {
+  return function create (roleBinding, options) {
+    options = options || {};
+    const clientConfig = privates.get(client).config;
+
+    const req = {
+      method: 'POST',
+      json: false,
+      url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/rolebindings`,
+      body: JSON.stringify(roleBinding)
+    };
+
+    return request(client, req).then((body) => {
+      return JSON.parse(body);
+    });
+  };
+}
+
+function remove (client) {
+  return function remove (roleBindingName, options) {
+    options = options || {};
+
+    if (!roleBindingName) {
+      return Promise.reject(new Error('Role Binding Name is required'));
+    }
+
+    const clientConfig = privates.get(client).config;
+
+    const req = {
+      method: 'DELETE',
+      url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/rolebindings/${roleBindingName}`,
+      qs: options.qs,
+      body: options.body
+    };
+
+    return request(client, req);
+  };
+}
+
+module.exports = {
+  findAll: findAll,
+  find: find,
+  create: create,
+  remove: remove
+};

--- a/lib/role-bindings.js
+++ b/lib/role-bindings.js
@@ -22,8 +22,7 @@ const request = require('./common-request');
 const privates = require('./private-map');
 
 function findAll (client) {
-  return function findAll (options) {
-    options = options || {};
+  return function findAll (options = {}) {
     const clientConfig = privates.get(client).config;
 
     const req = {
@@ -37,12 +36,12 @@ function findAll (client) {
 }
 
 function find (client) {
-  return function find (roleBindingName, options) {
-    options = options || {};
+  return function find (roleBindingName, options = {}) {
+    const clientConfig = privates.get(client).config;
+
     if (!roleBindingName) {
       return Promise.reject(new Error('Role Binding Name is required'));
     }
-    const clientConfig = privates.get(client).config;
 
     const req = {
       method: 'GET',
@@ -54,14 +53,34 @@ function find (client) {
 }
 
 function create (client) {
-  return function create (roleBinding, options) {
-    options = options || {};
+  return function create (roleBinding, options = {}) {
     const clientConfig = privates.get(client).config;
 
     const req = {
       method: 'POST',
-      json: false,
       url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/rolebindings`,
+      json: false,
+      body: JSON.stringify(roleBinding)
+    };
+
+    return request(client, req).then((body) => {
+      return JSON.parse(body);
+    });
+  };
+}
+
+function update (client) {
+  return function create (roleBindingName, roleBinding, options = {}) {
+    const clientConfig = privates.get(client).config;
+
+    if (!roleBindingName) {
+      return Promise.reject(new Error('Role Binding Name is required'));
+    }
+
+    const req = {
+      method: 'PUT',
+      json: false,
+      url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/rolebindings/${roleBindingName}`,
       body: JSON.stringify(roleBinding)
     };
 
@@ -72,20 +91,32 @@ function create (client) {
 }
 
 function remove (client) {
-  return function remove (roleBindingName, options) {
-    options = options || {};
+  return function remove (roleBindingName, options = {}) {
+    const clientConfig = privates.get(client).config;
 
     if (!roleBindingName) {
       return Promise.reject(new Error('Role Binding Name is required'));
     }
 
+    const req = {
+      method: 'DELETE',
+      url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/rolebindings/${roleBindingName}`,
+      body: options.body,
+      qs: options.qs
+    };
+
+    return request(client, req);
+  };
+}
+
+function removeAll (client) {
+  return function removeAll (options = {}) {
     const clientConfig = privates.get(client).config;
 
     const req = {
       method: 'DELETE',
-      url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/rolebindings/${roleBindingName}`,
-      qs: options.qs,
-      body: options.body
+      url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/rolebindings`,
+      qs: options.qs
     };
 
     return request(client, req);
@@ -96,5 +127,7 @@ module.exports = {
   findAll: findAll,
   find: find,
   create: create,
-  remove: remove
+  update: update,
+  remove: remove,
+  removeAll: removeAll
 };

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -18,13 +18,30 @@
  *
  */
 
-const privates = require('./private-map');
 const request = require('./common-request');
+const privates = require('./private-map');
 
-// Finds an image stream based on a namespace and build(?) name
-function find (client) {
-  return function find (routeName) {
+function findAll (client) {
+  return function findAll (options = {}) {
     const clientConfig = privates.get(client).config;
+
+    const req = {
+      method: 'GET',
+      url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/routes`,
+      qs: options.qs
+    };
+
+    return request(client, req);
+  };
+}
+
+function find (client) {
+  return function find (routeName, options = {}) {
+    const clientConfig = privates.get(client).config;
+
+    if (!routeName) {
+      return Promise.reject(new Error('Route Name is required'));
+    }
 
     const req = {
       method: 'GET',
@@ -36,16 +53,35 @@ function find (client) {
 }
 
 function create (client) {
-  return function create (routeConfig, options) {
-    options = options || {};
-
+  return function create (route, options = {}) {
     const clientConfig = privates.get(client).config;
 
     const req = {
       method: 'POST',
       url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/routes`,
       json: false,
-      body: JSON.stringify(routeConfig)
+      body: JSON.stringify(route)
+    };
+
+    return request(client, req).then((body) => {
+      return JSON.parse(body);
+    });
+  };
+}
+
+function update (client) {
+  return function create (routeName, route, options = {}) {
+    const clientConfig = privates.get(client).config;
+
+    if (!routeName) {
+      return Promise.reject(new Error('Route Name is required'));
+    }
+
+    const req = {
+      method: 'PUT',
+      json: false,
+      url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/routes/${routeName}`,
+      body: JSON.stringify(route)
     };
 
     return request(client, req).then((body) => {
@@ -55,14 +91,12 @@ function create (client) {
 }
 
 function remove (client) {
-  return function remove (routeName, options) {
-    options = options || {};
+  return function remove (routeName, options = {}) {
+    const clientConfig = privates.get(client).config;
 
     if (!routeName) {
       return Promise.reject(new Error('Route Name is required'));
     }
-
-    const clientConfig = privates.get(client).config;
 
     const req = {
       method: 'DELETE',
@@ -75,8 +109,25 @@ function remove (client) {
   };
 }
 
+function removeAll (client) {
+  return function removeAll (options = {}) {
+    const clientConfig = privates.get(client).config;
+
+    const req = {
+      method: 'DELETE',
+      url: `${client.apiUrl}/namespaces/${clientConfig.context.namespace}/routes`,
+      qs: options.qs
+    };
+
+    return request(client, req);
+  };
+}
+
 module.exports = {
+  findAll: findAll,
   find: find,
   create: create,
-  remove: remove
+  update: update,
+  remove: remove,
+  removeAll: removeAll
 };

--- a/lib/secrets.js
+++ b/lib/secrets.js
@@ -21,10 +21,8 @@
 const request = require('./common-request');
 const privates = require('./private-map');
 
-// find a list of secrets
 function findAll (client) {
-  return function findAll (options) {
-    options = options || {};
+  return function findAll (options = {}) {
     const clientConfig = privates.get(client).config;
 
     const req = {
@@ -37,20 +35,17 @@ function findAll (client) {
   };
 }
 
-// find just 1 secret
-// This could probably combined into 1 method with the above findAll
 function find (client) {
-  return function find (secretName, options) {
-    options = options || {};
+  return function find (secretName, options = {}) {
+    const clientConfig = privates.get(client).config;
+
     if (!secretName) {
       return Promise.reject(new Error('Secret Name is required'));
     }
-    const clientConfig = privates.get(client).config;
 
     const req = {
       method: 'GET',
-      url: `${client.kubeUrl}/namespaces/${clientConfig.context.namespace}/secrets/${secretName}`,
-      qs: options.qs
+      url: `${client.kubeUrl}/namespaces/${clientConfig.context.namespace}/secrets/${secretName}`
     };
 
     return request(client, req);
@@ -58,16 +53,35 @@ function find (client) {
 }
 
 function create (client) {
-  return function create (secretConfig, options) {
-    options = options || {};
-
+  return function create (secret, options = {}) {
     const clientConfig = privates.get(client).config;
 
     const req = {
       method: 'POST',
       url: `${client.kubeUrl}/namespaces/${clientConfig.context.namespace}/secrets`,
       json: false,
-      body: JSON.stringify(secretConfig)
+      body: JSON.stringify(secret)
+    };
+
+    return request(client, req).then((body) => {
+      return JSON.parse(body);
+    });
+  };
+}
+
+function update (client) {
+  return function create (secretName, secret, options = {}) {
+    const clientConfig = privates.get(client).config;
+
+    if (!secretName) {
+      return Promise.reject(new Error('Secret Name is required'));
+    }
+
+    const req = {
+      method: 'PUT',
+      json: false,
+      url: `${client.kubeUrl}/namespaces/${clientConfig.context.namespace}/secrets/${secretName}`,
+      body: JSON.stringify(secret)
     };
 
     return request(client, req).then((body) => {
@@ -77,14 +91,12 @@ function create (client) {
 }
 
 function remove (client) {
-  return function remove (secretName, options) {
-    options = options || {};
+  return function remove (secretName, options = {}) {
+    const clientConfig = privates.get(client).config;
 
     if (!secretName) {
       return Promise.reject(new Error('Secret Name is required'));
     }
-
-    const clientConfig = privates.get(client).config;
 
     const req = {
       method: 'DELETE',
@@ -98,9 +110,7 @@ function remove (client) {
 }
 
 function removeAll (client) {
-  return function removeAll (options) {
-    options = options || {};
-
+  return function removeAll (options = {}) {
     const clientConfig = privates.get(client).config;
 
     const req = {
@@ -117,6 +127,7 @@ module.exports = {
   findAll: findAll,
   find: find,
   create: create,
+  update: update,
   remove: remove,
   removeAll: removeAll
 };

--- a/lib/services.js
+++ b/lib/services.js
@@ -18,15 +18,31 @@
  *
  */
 
-const privates = require('./private-map');
 const request = require('./common-request');
+const privates = require('./private-map');
 
-// Finds an image stream based on a namespace and build(?) name
-function find (client) {
-  return function find (serviceName) {
+function findAll (client) {
+  return function findAll (options = {}) {
     const clientConfig = privates.get(client).config;
 
-    // Using api here instead of oapi
+    const req = {
+      method: 'GET',
+      url: `${client.kubeUrl}/namespaces/${clientConfig.context.namespace}/services`,
+      qs: options.qs
+    };
+
+    return request(client, req);
+  };
+}
+
+function find (client) {
+  return function find (serviceName, options = {}) {
+    const clientConfig = privates.get(client).config;
+
+    if (!serviceName) {
+      return Promise.reject(new Error('Service Name is required'));
+    }
+
     const req = {
       method: 'GET',
       url: `${client.kubeUrl}/namespaces/${clientConfig.context.namespace}/services/${serviceName}`
@@ -37,16 +53,35 @@ function find (client) {
 }
 
 function create (client) {
-  return function create (serviceConfig, options) {
-    options = options || {};
-
+  return function create (service, options = {}) {
     const clientConfig = privates.get(client).config;
 
     const req = {
       method: 'POST',
       url: `${client.kubeUrl}/namespaces/${clientConfig.context.namespace}/services`,
       json: false,
-      body: JSON.stringify(serviceConfig)
+      body: JSON.stringify(service)
+    };
+
+    return request(client, req).then((body) => {
+      return JSON.parse(body);
+    });
+  };
+}
+
+function update (client) {
+  return function create (serviceName, service, options = {}) {
+    const clientConfig = privates.get(client).config;
+
+    if (!serviceName) {
+      return Promise.reject(new Error('Service Name is required'));
+    }
+
+    const req = {
+      method: 'PUT',
+      json: false,
+      url: `${client.kubeUrl}/namespaces/${clientConfig.context.namespace}/services/${serviceName}`,
+      body: JSON.stringify(service)
     };
 
     return request(client, req).then((body) => {
@@ -56,18 +91,31 @@ function create (client) {
 }
 
 function remove (client) {
-  return function remove (serviceName, options) {
-    options = options || {};
+  return function remove (serviceName, options = {}) {
+    const clientConfig = privates.get(client).config;
 
     if (!serviceName) {
       return Promise.reject(new Error('Service Name is required'));
     }
 
+    const req = {
+      method: 'DELETE',
+      url: `${client.kubeUrl}/namespaces/${clientConfig.context.namespace}/services/${serviceName}`,
+      body: options.body,
+      qs: options.qs
+    };
+
+    return request(client, req);
+  };
+}
+
+function removeAll (client) {
+  return function removeAll (options = {}) {
     const clientConfig = privates.get(client).config;
 
     const req = {
       method: 'DELETE',
-      url: `${client.kubeUrl}/namespaces/${clientConfig.context.namespace}/services/${serviceName}`,
+      url: `${client.kubeUrl}/namespaces/${clientConfig.context.namespace}/services`,
       qs: options.qs
     };
 
@@ -76,7 +124,10 @@ function remove (client) {
 }
 
 module.exports = {
+  findAll: findAll,
   find: find,
   create: create,
-  remove: remove
+  update: update,
+  remove: remove,
+  removeAll: removeAll
 };

--- a/test/build-config-test.js
+++ b/test/build-config-test.js
@@ -134,6 +134,21 @@ test('update - buildconfig', (t) => {
   });
 });
 
+test('update - buildconfigs - update - no buildconfig name', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      client.buildconfigs.update().catch((err) => {
+        t.equal(err.message, 'Build Config Name is required', 'error message should return');
+        t.end();
+      });
+    });
+  });
+});
+
 test('remove - buildconfigs - basic removeAll', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`

--- a/test/build-config-test.js
+++ b/test/build-config-test.js
@@ -7,7 +7,33 @@ const openshiftRestClient = require('../');
 const openshiftConfigLoader = require('openshift-config-loader');
 const privates = require('../lib/private-map');
 
-test('find - build-config', (t) => {
+test('find - buildconfigs - basic findAll', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.buildconfigs.findAll, 'function', 'There is a findAll method on the buildconfigs object');
+
+      const clientConfig = privates.get(client).config;
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .get(`/oapi/v1/namespaces/${clientConfig.context.namespace}/buildconfigs`)
+        .reply(200, {kind: 'BuildConfigList'});
+
+      const findResult = client.buildconfigs.findAll().then((buildConfigList) => {
+        t.equal(buildConfigList.kind, 'BuildConfigList', 'returns an object with BuildConfigList');
+        t.end();
+      });
+
+      t.equal(findResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('find - buildconfigs - basic find', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
   };
@@ -17,7 +43,7 @@ test('find - build-config', (t) => {
       t.equal(typeof client.buildconfigs.find, 'function', 'There is a find method on the buildconfigs object');
 
       const clientConfig = privates.get(client).config;
-      const buildConfigName = 'nodejs-rest-http-s2i';
+      const buildConfigName = 'cool-buildconfig-name-1';
 
       nock(clientConfig.cluster)
         .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
@@ -34,42 +60,22 @@ test('find - build-config', (t) => {
   });
 });
 
-test('find - build-config - not found', (t) => {
+test('find - buildconfigs - find - no buildconfig name', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
   };
 
   openshiftConfigLoader(settings).then((config) => {
     openshiftRestClient(config).then((client) => {
-      const clientConfig = privates.get(client).config;
-      const buildConfigName = 'nodejs-rest-http-s2i-not-here';
-
-      const mockedErrorMessage = {
-        kind: 'Status',
-        apiVersion: 'v1',
-        metadata: {},
-        status: 'Failure',
-        message: 'buildconfigs "nodejs-rest-http-s2i-not-here" not found',
-        reason: 'NotFound',
-        details: { name: 'nodejs-rest-http-s2i-not-here', kind: 'buildconfigs' },
-        code: 404
-      };
-
-      nock(clientConfig.cluster)
-        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
-        .get(`/oapi/v1/namespaces/${clientConfig.context.namespace}/buildconfigs/${buildConfigName}`)
-        .reply(404, mockedErrorMessage);
-
-      client.buildconfigs.find(buildConfigName).then((buildconfig) => {
-        t.equal(buildconfig.kind, 'Status', 'returns an object with Status');
-        t.equal(buildconfig.code, 404, 'code with a 404');
+      client.buildconfigs.find().catch((err) => {
+        t.equal(err.message, 'Build Config Name is required', 'error message should return');
         t.end();
       });
     });
   });
 });
 
-test('create a build-config', (t) => {
+test('create - buildconfig', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
   };
@@ -79,23 +85,16 @@ test('create a build-config', (t) => {
       t.equal(typeof client.buildconfigs.create, 'function', 'There is a create method on the buildconfigs object');
 
       const clientConfig = privates.get(client).config;
-      const buildConfigName = 'nodejs-rest-http-s2i-test';
-
-      const buildConfig = {
-        apiVersion: 'v1',
-        kind: 'BuildConfig',
-        metadata: {
-          name: buildConfigName,
-          namespace: clientConfig.context.namespace
-        }
+      const buildconfig = {
+        kind: 'BuildConfig'
       };
 
       nock(clientConfig.cluster)
         .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
         .post(`/oapi/v1/namespaces/${clientConfig.context.namespace}/buildconfigs`)
-        .reply(201, buildConfig);
+        .reply(200, {kind: 'BuildConfig'});
 
-      const createResult = client.buildconfigs.create(buildConfig).then((buildconfig) => {
+      const createResult = client.buildconfigs.create(buildconfig).then((buildconfig) => {
         t.equal(buildconfig.kind, 'BuildConfig', 'returns an object with BuildConfig');
         t.end();
       });
@@ -105,17 +104,73 @@ test('create a build-config', (t) => {
   });
 });
 
-test('remove - build-config - basic remove', (t) => {
+test('update - buildconfig', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
   };
 
   openshiftConfigLoader(settings).then((config) => {
     openshiftRestClient(config).then((client) => {
-      t.equal(typeof client.buildconfigs.remove, 'function', 'There is a remove method on the build configs object');
+      t.equal(typeof client.buildconfigs.create, 'function', 'There is a create method on the buildconfigs object');
 
       const clientConfig = privates.get(client).config;
-      const buildConfigName = 'cool-deployment-name-1';
+      const buildconfig = {
+        kind: 'BuildConfig'
+      };
+      const buildConfigName = 'cool-buildconfig-name-1';
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .put(`/oapi/v1/namespaces/${clientConfig.context.namespace}/buildconfigs/${buildConfigName}`)
+        .reply(200, {kind: 'BuildConfig'});
+
+      const createResult = client.buildconfigs.update(buildConfigName, buildconfig).then((buildconfig) => {
+        t.equal(buildconfig.kind, 'BuildConfig', 'returns an object with BuildConfig');
+        t.end();
+      });
+
+      t.equal(createResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('remove - buildconfigs - basic removeAll', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.buildconfigs.removeAll, 'function', 'There is a removeAll method on the buildconfigs object');
+
+      const clientConfig = privates.get(client).config;
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .delete(`/oapi/v1/namespaces/${clientConfig.context.namespace}/buildconfigs`)
+        .reply(200, {kind: 'Status'});
+
+      const removeResult = client.buildconfigs.removeAll().then((buildConfigList) => {
+        t.equal(buildConfigList.kind, 'Status', 'returns an object with Status');
+        t.end();
+      });
+
+      t.equal(removeResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('remove - buildconfigs - basic remove', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.buildconfigs.remove, 'function', 'There is a remove method on the buildconfigs object');
+
+      const clientConfig = privates.get(client).config;
+      const buildConfigName = 'cool-buildconfig-name-1';
 
       nock(clientConfig.cluster)
         .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
@@ -132,7 +187,7 @@ test('remove - build-config - basic remove', (t) => {
   });
 });
 
-test('remove - build-configs - remove - no build config name', (t) => {
+test('remove - buildconfigs - remove - no buildconfig name', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
   };

--- a/test/build-test.js
+++ b/test/build-test.js
@@ -134,6 +134,21 @@ test('update - build', (t) => {
   });
 });
 
+test('update - builds - update - no build name', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      client.builds.update().catch((err) => {
+        t.equal(err.message, 'Build Name is required', 'error message should return');
+        t.end();
+      });
+    });
+  });
+});
+
 test('remove - builds - basic removeAll', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`

--- a/test/build-test.js
+++ b/test/build-test.js
@@ -7,17 +7,43 @@ const openshiftRestClient = require('../');
 const openshiftConfigLoader = require('openshift-config-loader');
 const privates = require('../lib/private-map');
 
-test('find - build', (t) => {
+test('find - builds - basic findAll', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
   };
 
   openshiftConfigLoader(settings).then((config) => {
     openshiftRestClient(config).then((client) => {
-      t.equal(typeof client.builds.find, 'function', 'There is a find method on the build object');
+      t.equal(typeof client.builds.findAll, 'function', 'There is a findAll method on the builds object');
 
       const clientConfig = privates.get(client).config;
-      const buildName = 'nodejs-rest-http-s2i';
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .get(`/oapi/v1/namespaces/${clientConfig.context.namespace}/builds`)
+        .reply(200, {kind: 'BuildList'});
+
+      const findResult = client.builds.findAll().then((buildList) => {
+        t.equal(buildList.kind, 'BuildList', 'returns an object with BuildList');
+        t.end();
+      });
+
+      t.equal(findResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('find - builds - basic find', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.builds.find, 'function', 'There is a find method on the builds object');
+
+      const clientConfig = privates.get(client).config;
+      const buildName = 'cool-build-name-1';
 
       nock(clientConfig.cluster)
         .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
@@ -34,55 +60,117 @@ test('find - build', (t) => {
   });
 });
 
-test('findall - build', (t) => {
+test('find - builds - find - no build name', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
   };
 
   openshiftConfigLoader(settings).then((config) => {
     openshiftRestClient(config).then((client) => {
-      t.equal(typeof client.builds.find, 'function', 'There is a find method on the build object');
-
-      const clientConfig = privates.get(client).config;
-
-      const buildList = {
-        kind: 'BuildList',
-        items: [
-          {
-            metadata: {
-              name: 'nodejs-rest-http-s2i-1'
-            }
-          }
-        ]
-      };
-
-      nock(clientConfig.cluster)
-        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
-        .get(`/oapi/v1/namespaces/${clientConfig.context.namespace}/builds`)
-        .reply(200, buildList);
-
-      const findResult = client.builds.findAll().then((buildList) => {
-        t.equal(buildList.kind, 'BuildList', 'returns an object with Build');
-        t.equal(buildList.items[0].metadata.name, 'nodejs-rest-http-s2i-1', 'should have the build name');
+      client.builds.find().catch((err) => {
+        t.equal(err.message, 'Build Name is required', 'error message should return');
         t.end();
       });
-
-      t.equal(findResult instanceof Promise, true, 'should return a Promise');
     });
   });
 });
 
-test('remove - build - basic remove', (t) => {
+test('create - build', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
   };
 
   openshiftConfigLoader(settings).then((config) => {
     openshiftRestClient(config).then((client) => {
-      t.equal(typeof client.builds.remove, 'function', 'There is a remove method on the build object');
+      t.equal(typeof client.builds.create, 'function', 'There is a create method on the builds object');
 
       const clientConfig = privates.get(client).config;
-      const buildName = 'cool-deployment-name-1';
+      const build = {
+        kind: 'Build'
+      };
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .post(`/oapi/v1/namespaces/${clientConfig.context.namespace}/builds`)
+        .reply(200, {kind: 'Build'});
+
+      const createResult = client.builds.create(build).then((build) => {
+        t.equal(build.kind, 'Build', 'returns an object with Build');
+        t.end();
+      });
+
+      t.equal(createResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('update - build', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.builds.create, 'function', 'There is a create method on the builds object');
+
+      const clientConfig = privates.get(client).config;
+      const build = {
+        kind: 'Build'
+      };
+      const buildName = 'cool-build-name-1';
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .put(`/oapi/v1/namespaces/${clientConfig.context.namespace}/builds/${buildName}`)
+        .reply(200, {kind: 'Build'});
+
+      const createResult = client.builds.update(buildName, build).then((build) => {
+        t.equal(build.kind, 'Build', 'returns an object with Build');
+        t.end();
+      });
+
+      t.equal(createResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('remove - builds - basic removeAll', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.builds.removeAll, 'function', 'There is a removeAll method on the builds object');
+
+      const clientConfig = privates.get(client).config;
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .delete(`/oapi/v1/namespaces/${clientConfig.context.namespace}/builds`)
+        .reply(200, {kind: 'Status'});
+
+      const removeResult = client.builds.removeAll().then((buildList) => {
+        t.equal(buildList.kind, 'Status', 'returns an object with Status');
+        t.end();
+      });
+
+      t.equal(removeResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('remove - builds - basic remove', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.builds.remove, 'function', 'There is a remove method on the builds object');
+
+      const clientConfig = privates.get(client).config;
+      const buildName = 'cool-build-name-1';
 
       nock(clientConfig.cluster)
         .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
@@ -99,7 +187,7 @@ test('remove - build - basic remove', (t) => {
   });
 });
 
-test('remove - build - remove - no build name', (t) => {
+test('remove - builds - remove - no build name', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
   };

--- a/test/cluster-role-binding-test.js
+++ b/test/cluster-role-binding-test.js
@@ -1,0 +1,147 @@
+'use strict';
+
+const test = require('tape');
+const nock = require('nock');
+
+const openshiftRestClient = require('../');
+const openshiftConfigLoader = require('openshift-config-loader');
+const privates = require('../lib/private-map');
+
+test('find - clusterrolebindings - basic findAll', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.clusterrolebindings.findAll, 'function', 'There is a findAll method on the clusterrolebindings object');
+
+      const clientConfig = privates.get(client).config;
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .get(`/oapi/v1/clusterrolebindings`)
+        .reply(200, {kind: 'ClusterRoleBindingList'});
+
+      const findResult = client.clusterrolebindings.findAll().then((clusterRoleBindingList) => {
+        t.equal(clusterRoleBindingList.kind, 'ClusterRoleBindingList', 'returns an object with ClusterRoleBindingList');
+        t.end();
+      });
+
+      t.equal(findResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('find - clusterrolebindings - basic find', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.clusterrolebindings.find, 'function', 'There is a find method on the clusterrolebindings object');
+
+      const clientConfig = privates.get(client).config;
+      const clusterRoleBindingName = 'cool-clusterrolebinding-name-1';
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .get(`/oapi/v1/clusterrolebindings/${clusterRoleBindingName}`)
+        .reply(200, {kind: 'ClusterRoleBinding'});
+
+      const findResult = client.clusterrolebindings.find(clusterRoleBindingName).then((clusterrolebinding) => {
+        t.equal(clusterrolebinding.kind, 'ClusterRoleBinding', 'returns an object with ClusterRoleBinding');
+        t.end();
+      });
+
+      t.equal(findResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('find - clusterrolebindings - find - no clusterrolebinding name', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      client.clusterrolebindings.find().catch((err) => {
+        t.equal(err.message, 'Cluster Role Binding Name is required', 'error message should return');
+        t.end();
+      });
+    });
+  });
+});
+
+test('create - clusterrolebinding', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.clusterrolebindings.create, 'function', 'There is a create method on the clusterrolebindings object');
+
+      const clientConfig = privates.get(client).config;
+      const clusterrolebinding = {
+        kind: 'ClusterRoleBinding'
+      };
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .post(`/oapi/v1/clusterrolebindings`)
+        .reply(200, {kind: 'ClusterRoleBinding'});
+
+      const createResult = client.clusterrolebindings.create(clusterrolebinding).then((clusterrolebinding) => {
+        t.equal(clusterrolebinding.kind, 'ClusterRoleBinding', 'returns an object with ClusterRoleBinding');
+        t.end();
+      });
+
+      t.equal(createResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('remove - clusterrolebindings - basic remove', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.clusterrolebindings.remove, 'function', 'There is a remove method on the clusterrolebindings object');
+
+      const clientConfig = privates.get(client).config;
+      const clusterRoleBindingName = 'cool-clusterrolebinding-name-1';
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .delete(`/oapi/v1/clusterrolebindings/${clusterRoleBindingName}`)
+        .reply(200, {kind: 'Status'});
+
+      const removeResult = client.clusterrolebindings.remove(clusterRoleBindingName).then((status) => {
+        t.equal(status.kind, 'Status', 'returns an object with Status');
+        t.end();
+      });
+
+      t.equal(removeResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('remove - clusterrolebindings - remove - no clusterrolebinding name', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      client.clusterrolebindings.remove().catch((err) => {
+        t.equal(err.message, 'Cluster Role Binding Name is required', 'error message should return');
+        t.end();
+      });
+    });
+  });
+});

--- a/test/configmaps-test.js
+++ b/test/configmaps-test.js
@@ -134,6 +134,21 @@ test('update - configmap', (t) => {
   });
 });
 
+test('update - configmaps - update - no configmap name', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      client.configmaps.update().catch((err) => {
+        t.equal(err.message, 'Config Map Name is required', 'error message should return');
+        t.end();
+      });
+    });
+  });
+});
+
 test('remove - configmaps - basic removeAll', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`

--- a/test/configmaps-test.js
+++ b/test/configmaps-test.js
@@ -7,6 +7,32 @@ const openshiftRestClient = require('../');
 const openshiftConfigLoader = require('openshift-config-loader');
 const privates = require('../lib/private-map');
 
+test('find - configmaps - basic findAll', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.configmaps.findAll, 'function', 'There is a findAll method on the configmaps object');
+
+      const clientConfig = privates.get(client).config;
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .get(`/api/v1/namespaces/${clientConfig.context.namespace}/configmaps`)
+        .reply(200, {kind: 'ConfigMapList'});
+
+      const findResult = client.configmaps.findAll().then((configMapList) => {
+        t.equal(configMapList.kind, 'ConfigMapList', 'returns an object with ConfigMapList');
+        t.end();
+      });
+
+      t.equal(findResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
 test('find - configmaps - basic find', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
@@ -17,15 +43,15 @@ test('find - configmaps - basic find', (t) => {
       t.equal(typeof client.configmaps.find, 'function', 'There is a find method on the configmaps object');
 
       const clientConfig = privates.get(client).config;
-      const configMapName = 'cool-deployment-name-1';
+      const configMapName = 'cool-configmap-name-1';
 
       nock(clientConfig.cluster)
         .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
         .get(`/api/v1/namespaces/${clientConfig.context.namespace}/configmaps/${configMapName}`)
         .reply(200, {kind: 'ConfigMap'});
 
-      const findResult = client.configmaps.find(configMapName).then((configMap) => {
-        t.equal(configMap.kind, 'ConfigMap', 'returns an object with configMap');
+      const findResult = client.configmaps.find(configMapName).then((configmap) => {
+        t.equal(configmap.kind, 'ConfigMap', 'returns an object with ConfigMap');
         t.end();
       });
 
@@ -34,7 +60,7 @@ test('find - configmaps - basic find', (t) => {
   });
 });
 
-test('find - configmaps - find - no configMap name', (t) => {
+test('find - configmaps - find - no configmap name', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
   };
@@ -42,7 +68,134 @@ test('find - configmaps - find - no configMap name', (t) => {
   openshiftConfigLoader(settings).then((config) => {
     openshiftRestClient(config).then((client) => {
       client.configmaps.find().catch((err) => {
-        t.equal(err.message, 'ConfigMap Name is required', 'error message should return');
+        t.equal(err.message, 'Config Map Name is required', 'error message should return');
+        t.end();
+      });
+    });
+  });
+});
+
+test('create - configmap', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.configmaps.create, 'function', 'There is a create method on the configmaps object');
+
+      const clientConfig = privates.get(client).config;
+      const configmap = {
+        kind: 'ConfigMap'
+      };
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .post(`/api/v1/namespaces/${clientConfig.context.namespace}/configmaps`)
+        .reply(200, {kind: 'ConfigMap'});
+
+      const createResult = client.configmaps.create(configmap).then((configmap) => {
+        t.equal(configmap.kind, 'ConfigMap', 'returns an object with ConfigMap');
+        t.end();
+      });
+
+      t.equal(createResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('update - configmap', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.configmaps.create, 'function', 'There is a create method on the configmaps object');
+
+      const clientConfig = privates.get(client).config;
+      const configmap = {
+        kind: 'ConfigMap'
+      };
+      const configMapName = 'cool-configmap-name-1';
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .put(`/api/v1/namespaces/${clientConfig.context.namespace}/configmaps/${configMapName}`)
+        .reply(200, {kind: 'ConfigMap'});
+
+      const createResult = client.configmaps.update(configMapName, configmap).then((configmap) => {
+        t.equal(configmap.kind, 'ConfigMap', 'returns an object with ConfigMap');
+        t.end();
+      });
+
+      t.equal(createResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('remove - configmaps - basic removeAll', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.configmaps.removeAll, 'function', 'There is a removeAll method on the configmaps object');
+
+      const clientConfig = privates.get(client).config;
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .delete(`/api/v1/namespaces/${clientConfig.context.namespace}/configmaps`)
+        .reply(200, {kind: 'Status'});
+
+      const removeResult = client.configmaps.removeAll().then((configMapList) => {
+        t.equal(configMapList.kind, 'Status', 'returns an object with Status');
+        t.end();
+      });
+
+      t.equal(removeResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('remove - configmaps - basic remove', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.configmaps.remove, 'function', 'There is a remove method on the configmaps object');
+
+      const clientConfig = privates.get(client).config;
+      const configMapName = 'cool-configmap-name-1';
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .delete(`/api/v1/namespaces/${clientConfig.context.namespace}/configmaps/${configMapName}`)
+        .reply(200, {kind: 'Status'});
+
+      const removeResult = client.configmaps.remove(configMapName).then((status) => {
+        t.equal(status.kind, 'Status', 'returns an object with Status');
+        t.end();
+      });
+
+      t.equal(removeResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('remove - configmaps - remove - no configmap name', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      client.configmaps.remove().catch((err) => {
+        t.equal(err.message, 'Config Map Name is required', 'error message should return');
         t.end();
       });
     });

--- a/test/deployment-config-test.js
+++ b/test/deployment-config-test.js
@@ -134,6 +134,21 @@ test('update - deploymentconfig', (t) => {
   });
 });
 
+test('update - deploymentconfigs - update - no deploymentconfig name', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      client.deploymentconfigs.update().catch((err) => {
+        t.equal(err.message, 'Deployment Config Name is required', 'error message should return');
+        t.end();
+      });
+    });
+  });
+});
+
 test('remove - deploymentconfigs - basic removeAll', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`

--- a/test/deployment-config-test.js
+++ b/test/deployment-config-test.js
@@ -7,7 +7,33 @@ const openshiftRestClient = require('../');
 const openshiftConfigLoader = require('openshift-config-loader');
 const privates = require('../lib/private-map');
 
-test('find - deployment-config', (t) => {
+test('find - deploymentconfigs - basic findAll', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.deploymentconfigs.findAll, 'function', 'There is a findAll method on the deploymentconfigs object');
+
+      const clientConfig = privates.get(client).config;
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .get(`/oapi/v1/namespaces/${clientConfig.context.namespace}/deploymentconfigs`)
+        .reply(200, {kind: 'DeploymentConfigList'});
+
+      const findResult = client.deploymentconfigs.findAll().then((deploymentConfigList) => {
+        t.equal(deploymentConfigList.kind, 'DeploymentConfigList', 'returns an object with DeploymentConfigList');
+        t.end();
+      });
+
+      t.equal(findResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('find - deploymentconfigs - basic find', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
   };
@@ -17,14 +43,14 @@ test('find - deployment-config', (t) => {
       t.equal(typeof client.deploymentconfigs.find, 'function', 'There is a find method on the deploymentconfigs object');
 
       const clientConfig = privates.get(client).config;
-      const deploymentconfigName = 'nodejs-rest-http';
+      const deploymentConfigName = 'cool-deploymentconfig-name-1';
 
       nock(clientConfig.cluster)
         .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
-        .get(`/oapi/v1/namespaces/${clientConfig.context.namespace}/deploymentconfigs/${deploymentconfigName}`)
+        .get(`/oapi/v1/namespaces/${clientConfig.context.namespace}/deploymentconfigs/${deploymentConfigName}`)
         .reply(200, {kind: 'DeploymentConfig'});
 
-      const findResult = client.deploymentconfigs.find(deploymentconfigName).then((deploymentconfig) => {
+      const findResult = client.deploymentconfigs.find(deploymentConfigName).then((deploymentconfig) => {
         t.equal(deploymentconfig.kind, 'DeploymentConfig', 'returns an object with DeploymentConfig');
         t.end();
       });
@@ -34,17 +60,32 @@ test('find - deployment-config', (t) => {
   });
 });
 
-test('create - deployment-config', (t) => {
+test('find - deploymentconfigs - find - no deploymentconfig name', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
   };
 
   openshiftConfigLoader(settings).then((config) => {
     openshiftRestClient(config).then((client) => {
-      t.equal(typeof client.deploymentconfigs.find, 'function', 'There is a find method on the deploymentconfigs object');
+      client.deploymentconfigs.find().catch((err) => {
+        t.equal(err.message, 'Deployment Config Name is required', 'error message should return');
+        t.end();
+      });
+    });
+  });
+});
+
+test('create - deploymentconfig', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.deploymentconfigs.create, 'function', 'There is a create method on the deploymentconfigs object');
 
       const clientConfig = privates.get(client).config;
-      const deploymentConfig = {
+      const deploymentconfig = {
         kind: 'DeploymentConfig'
       };
 
@@ -53,7 +94,7 @@ test('create - deployment-config', (t) => {
         .post(`/oapi/v1/namespaces/${clientConfig.context.namespace}/deploymentconfigs`)
         .reply(200, {kind: 'DeploymentConfig'});
 
-      const createResult = client.deploymentconfigs.create(deploymentConfig).then((deploymentconfig) => {
+      const createResult = client.deploymentconfigs.create(deploymentconfig).then((deploymentconfig) => {
         t.equal(deploymentconfig.kind, 'DeploymentConfig', 'returns an object with DeploymentConfig');
         t.end();
       });
@@ -63,7 +104,63 @@ test('create - deployment-config', (t) => {
   });
 });
 
-test('remove - deployment config - basic remove', (t) => {
+test('update - deploymentconfig', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.deploymentconfigs.create, 'function', 'There is a create method on the deploymentconfigs object');
+
+      const clientConfig = privates.get(client).config;
+      const deploymentconfig = {
+        kind: 'DeploymentConfig'
+      };
+      const deploymentConfigName = 'cool-deploymentconfig-name-1';
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .put(`/oapi/v1/namespaces/${clientConfig.context.namespace}/deploymentconfigs/${deploymentConfigName}`)
+        .reply(200, {kind: 'DeploymentConfig'});
+
+      const createResult = client.deploymentconfigs.update(deploymentConfigName, deploymentconfig).then((deploymentconfig) => {
+        t.equal(deploymentconfig.kind, 'DeploymentConfig', 'returns an object with DeploymentConfig');
+        t.end();
+      });
+
+      t.equal(createResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('remove - deploymentconfigs - basic removeAll', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.deploymentconfigs.removeAll, 'function', 'There is a removeAll method on the deploymentconfigs object');
+
+      const clientConfig = privates.get(client).config;
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .delete(`/oapi/v1/namespaces/${clientConfig.context.namespace}/deploymentconfigs`)
+        .reply(200, {kind: 'Status'});
+
+      const removeResult = client.deploymentconfigs.removeAll().then((deploymentConfigList) => {
+        t.equal(deploymentConfigList.kind, 'Status', 'returns an object with Status');
+        t.end();
+      });
+
+      t.equal(removeResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('remove - deploymentconfigs - basic remove', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
   };
@@ -73,7 +170,7 @@ test('remove - deployment config - basic remove', (t) => {
       t.equal(typeof client.deploymentconfigs.remove, 'function', 'There is a remove method on the deploymentconfigs object');
 
       const clientConfig = privates.get(client).config;
-      const deploymentConfigName = 'cool-deployment-name';
+      const deploymentConfigName = 'cool-deploymentconfig-name-1';
 
       nock(clientConfig.cluster)
         .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
@@ -90,7 +187,7 @@ test('remove - deployment config - basic remove', (t) => {
   });
 });
 
-test('remove - deployment config - remove - no rep name', (t) => {
+test('remove - deploymentconfigs - remove - no deploymentconfig name', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
   };

--- a/test/group-test.js
+++ b/test/group-test.js
@@ -1,0 +1,203 @@
+'use strict';
+
+const test = require('tape');
+const nock = require('nock');
+
+const openshiftRestClient = require('../');
+const openshiftConfigLoader = require('openshift-config-loader');
+const privates = require('../lib/private-map');
+
+test('find - groups - basic findAll', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.groups.findAll, 'function', 'There is a findAll method on the groups object');
+
+      const clientConfig = privates.get(client).config;
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .get(`/oapi/v1/groups`)
+        .reply(200, {kind: 'GroupList'});
+
+      const findResult = client.groups.findAll().then((groupList) => {
+        t.equal(groupList.kind, 'GroupList', 'returns an object with GroupList');
+        t.end();
+      });
+
+      t.equal(findResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('find - groups - basic find', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.groups.find, 'function', 'There is a find method on the groups object');
+
+      const clientConfig = privates.get(client).config;
+      const groupName = 'cool-group-name-1';
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .get(`/oapi/v1/groups/${groupName}`)
+        .reply(200, {kind: 'Group'});
+
+      const findResult = client.groups.find(groupName).then((group) => {
+        t.equal(group.kind, 'Group', 'returns an object with Group');
+        t.end();
+      });
+
+      t.equal(findResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('find - groups - find - no group name', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      client.groups.find().catch((err) => {
+        t.equal(err.message, 'Group Name is required', 'error message should return');
+        t.end();
+      });
+    });
+  });
+});
+
+test('create - group', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.groups.create, 'function', 'There is a create method on the groups object');
+
+      const clientConfig = privates.get(client).config;
+      const group = {
+        kind: 'Group'
+      };
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .post(`/oapi/v1/groups`)
+        .reply(200, {kind: 'Group'});
+
+      const createResult = client.groups.create(group).then((group) => {
+        t.equal(group.kind, 'Group', 'returns an object with Group');
+        t.end();
+      });
+
+      t.equal(createResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('update - group', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.groups.create, 'function', 'There is a create method on the groups object');
+
+      const clientConfig = privates.get(client).config;
+      const group = {
+        kind: 'Group'
+      };
+      const groupName = 'cool-group-name-1';
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .put(`/oapi/v1/groups/${groupName}`)
+        .reply(200, {kind: 'Group'});
+
+      const createResult = client.groups.update(groupName, group).then((group) => {
+        t.equal(group.kind, 'Group', 'returns an object with Group');
+        t.end();
+      });
+
+      t.equal(createResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('remove - groups - basic removeAll', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.groups.removeAll, 'function', 'There is a removeAll method on the groups object');
+
+      const clientConfig = privates.get(client).config;
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .delete(`/oapi/v1/groups`)
+        .reply(200, {kind: 'Status'});
+
+      const removeResult = client.groups.removeAll().then((groupList) => {
+        t.equal(groupList.kind, 'Status', 'returns an object with Status');
+        t.end();
+      });
+
+      t.equal(removeResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('remove - groups - basic remove', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.groups.remove, 'function', 'There is a remove method on the groups object');
+
+      const clientConfig = privates.get(client).config;
+      const groupName = 'cool-group-name-1';
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .delete(`/oapi/v1/groups/${groupName}`)
+        .reply(200, {kind: 'Status'});
+
+      const removeResult = client.groups.remove(groupName).then((status) => {
+        t.equal(status.kind, 'Status', 'returns an object with Status');
+        t.end();
+      });
+
+      t.equal(removeResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('remove - groups - remove - no group name', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      client.groups.remove().catch((err) => {
+        t.equal(err.message, 'Group Name is required', 'error message should return');
+        t.end();
+      });
+    });
+  });
+});

--- a/test/group-test.js
+++ b/test/group-test.js
@@ -134,6 +134,22 @@ test('update - group', (t) => {
   });
 });
 
+test('update - groups - update - no group name', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      client.groups.update().catch((
+        err) => {
+        t.equal(err.message, 'Group Name is required', 'error message should return');
+        t.end();
+      });
+    });
+  });
+});
+
 test('remove - groups - basic removeAll', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`

--- a/test/imagestream-test.js
+++ b/test/imagestream-test.js
@@ -7,7 +7,33 @@ const openshiftRestClient = require('../');
 const openshiftConfigLoader = require('openshift-config-loader');
 const privates = require('../lib/private-map');
 
-test('find - imagestreams', (t) => {
+test('find - imagestreams - basic findAll', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.imagestreams.findAll, 'function', 'There is a findAll method on the imagestreams object');
+
+      const clientConfig = privates.get(client).config;
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .get(`/oapi/v1/namespaces/${clientConfig.context.namespace}/imagestreams`)
+        .reply(200, {kind: 'ImageStreamList'});
+
+      const findResult = client.imagestreams.findAll().then((imageStreamList) => {
+        t.equal(imageStreamList.kind, 'ImageStreamList', 'returns an object with ImageStreamList');
+        t.end();
+      });
+
+      t.equal(findResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('find - imagestreams - basic find', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
   };
@@ -17,15 +43,15 @@ test('find - imagestreams', (t) => {
       t.equal(typeof client.imagestreams.find, 'function', 'There is a find method on the imagestreams object');
 
       const clientConfig = privates.get(client).config;
-      const imagestreamsName = 'nodejs-rest-http';
+      const imageStreamName = 'cool-imagestream-name-1';
 
       nock(clientConfig.cluster)
         .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
-        .get(`/oapi/v1/namespaces/${clientConfig.context.namespace}/imagestreams/${imagestreamsName}`)
-        .reply(200, {kind: 'Imagestream'});
+        .get(`/oapi/v1/namespaces/${clientConfig.context.namespace}/imagestreams/${imageStreamName}`)
+        .reply(200, {kind: 'ImageStream'});
 
-      const findResult = client.imagestreams.find(imagestreamsName).then((imagestream) => {
-        t.equal(imagestream.kind, 'Imagestream', 'returns an object with Imagestream');
+      const findResult = client.imagestreams.find(imageStreamName).then((imagestream) => {
+        t.equal(imagestream.kind, 'ImageStream', 'returns an object with ImageStream');
         t.end();
       });
 
@@ -34,7 +60,22 @@ test('find - imagestreams', (t) => {
   });
 });
 
-test('create - imagestreams', (t) => {
+test('find - imagestreams - find - no imagestream name', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      client.imagestreams.find().catch((err) => {
+        t.equal(err.message, 'Image Stream Name is required', 'error message should return');
+        t.end();
+      });
+    });
+  });
+});
+
+test('create - imagestream', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
   };
@@ -63,6 +104,62 @@ test('create - imagestreams', (t) => {
   });
 });
 
+test('update - imagestream', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.imagestreams.create, 'function', 'There is a create method on the imagestreams object');
+
+      const clientConfig = privates.get(client).config;
+      const imagestream = {
+        kind: 'ImageStream'
+      };
+      const imageStreamName = 'cool-imagestream-name-1';
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .put(`/oapi/v1/namespaces/${clientConfig.context.namespace}/imagestreams/${imageStreamName}`)
+        .reply(200, {kind: 'ImageStream'});
+
+      const createResult = client.imagestreams.update(imageStreamName, imagestream).then((imagestream) => {
+        t.equal(imagestream.kind, 'ImageStream', 'returns an object with ImageStream');
+        t.end();
+      });
+
+      t.equal(createResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('remove - imagestreams - basic removeAll', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.imagestreams.removeAll, 'function', 'There is a removeAll method on the imagestreams object');
+
+      const clientConfig = privates.get(client).config;
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .delete(`/oapi/v1/namespaces/${clientConfig.context.namespace}/imagestreams`)
+        .reply(200, {kind: 'Status'});
+
+      const removeResult = client.imagestreams.removeAll().then((imageStreamList) => {
+        t.equal(imageStreamList.kind, 'Status', 'returns an object with Status');
+        t.end();
+      });
+
+      t.equal(removeResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
 test('remove - imagestreams - basic remove', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
@@ -70,10 +167,10 @@ test('remove - imagestreams - basic remove', (t) => {
 
   openshiftConfigLoader(settings).then((config) => {
     openshiftRestClient(config).then((client) => {
-      t.equal(typeof client.imagestreams.remove, 'function', 'There is a remove method on the image streams object');
+      t.equal(typeof client.imagestreams.remove, 'function', 'There is a remove method on the imagestreams object');
 
       const clientConfig = privates.get(client).config;
-      const imageStreamName = 'cool-deployment-name-1';
+      const imageStreamName = 'cool-imagestream-name-1';
 
       nock(clientConfig.cluster)
         .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
@@ -90,7 +187,7 @@ test('remove - imagestreams - basic remove', (t) => {
   });
 });
 
-test('remove - imagestreams - remove - no build config name', (t) => {
+test('remove - imagestreams - remove - no imagestream name', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
   };

--- a/test/imagestream-test.js
+++ b/test/imagestream-test.js
@@ -134,6 +134,21 @@ test('update - imagestream', (t) => {
   });
 });
 
+test('update - imagestreams - update - no imagestream name', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      client.imagestreams.update().catch((err) => {
+        t.equal(err.message, 'Image Stream Name is required', 'error message should return');
+        t.end();
+      });
+    });
+  });
+});
+
 test('remove - imagestreams - basic removeAll', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`

--- a/test/pods-test.js
+++ b/test/pods-test.js
@@ -1,0 +1,203 @@
+'use strict';
+
+const test = require('tape');
+const nock = require('nock');
+
+const openshiftRestClient = require('../');
+const openshiftConfigLoader = require('openshift-config-loader');
+const privates = require('../lib/private-map');
+
+test('find - pods - basic findAll', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.pods.findAll, 'function', 'There is a findAll method on the pods object');
+
+      const clientConfig = privates.get(client).config;
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .get(`/api/v1/namespaces/${clientConfig.context.namespace}/pods`)
+        .reply(200, {kind: 'PodList'});
+
+      const findResult = client.pods.findAll().then((podsList) => {
+        t.equal(podsList.kind, 'PodList', 'returns an object with PodList');
+        t.end();
+      });
+
+      t.equal(findResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('find - pods - basic find', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.pods.find, 'function', 'There is a find method on the pods object');
+
+      const clientConfig = privates.get(client).config;
+      const podName = 'cool-pod-name-1';
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .get(`/api/v1/namespaces/${clientConfig.context.namespace}/pods/${podName}`)
+        .reply(200, {kind: 'Pod'});
+
+      const findResult = client.pods.find(podName).then((pod) => {
+        t.equal(pod.kind, 'Pod', 'returns an object with Pod');
+        t.end();
+      });
+
+      t.equal(findResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('find - pods - find - no pod name', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      client.pods.find().catch((err) => {
+        t.equal(err.message, 'Pod Name is required', 'error message should return');
+        t.end();
+      });
+    });
+  });
+});
+
+test('create - pod', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.pods.create, 'function', 'There is a create method on the pods object');
+
+      const clientConfig = privates.get(client).config;
+      const pod = {
+        kind: 'Pod'
+      };
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .post(`/api/v1/namespaces/${clientConfig.context.namespace}/pods`)
+        .reply(200, {kind: 'Pod'});
+
+      const createResult = client.pods.create(pod).then((pod) => {
+        t.equal(pod.kind, 'Pod', 'returns an object with Pod');
+        t.end();
+      });
+
+      t.equal(createResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('update - pod', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.pods.create, 'function', 'There is a create method on the pods object');
+
+      const clientConfig = privates.get(client).config;
+      const pod = {
+        kind: 'Pod'
+      };
+      const podName = 'cool-pod-name-1';
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .put(`/api/v1/namespaces/${clientConfig.context.namespace}/pods/${podName}`)
+        .reply(200, {kind: 'Pod'});
+
+      const createResult = client.pods.update(podName, pod).then((pod) => {
+        t.equal(pod.kind, 'Pod', 'returns an object with Pod');
+        t.end();
+      });
+
+      t.equal(createResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('remove - pods - basic removeAll', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.pods.removeAll, 'function', 'There is a removeAll method on the pods object');
+
+      const clientConfig = privates.get(client).config;
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .delete(`/api/v1/namespaces/${clientConfig.context.namespace}/pods`)
+        .reply(200, {kind: 'Status'});
+
+      const removeResult = client.pods.removeAll().then((podsList) => {
+        t.equal(podsList.kind, 'Status', 'returns an object with Status');
+        t.end();
+      });
+
+      t.equal(removeResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('remove - pods - basic remove', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.pods.remove, 'function', 'There is a remove method on the pods object');
+
+      const clientConfig = privates.get(client).config;
+      const podName = 'cool-pod-name-1';
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .delete(`/api/v1/namespaces/${clientConfig.context.namespace}/pods/${podName}`)
+        .reply(200, {kind: 'Status'});
+
+      const removeResult = client.pods.remove(podName).then((status) => {
+        t.equal(status.kind, 'Status', 'returns an object with Status');
+        t.end();
+      });
+
+      t.equal(removeResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('remove - pods - remove - no pod name', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      client.pods.remove().catch((err) => {
+        t.equal(err.message, 'Pod Name is required', 'error message should return');
+        t.end();
+      });
+    });
+  });
+});

--- a/test/pods-test.js
+++ b/test/pods-test.js
@@ -134,6 +134,21 @@ test('update - pod', (t) => {
   });
 });
 
+test('update - pods - update - no pod name', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      client.pods.update().catch((err) => {
+        t.equal(err.message, 'Pod Name is required', 'error message should return');
+        t.end();
+      });
+    });
+  });
+});
+
 test('remove - pods - basic removeAll', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`

--- a/test/project-request-test.js
+++ b/test/project-request-test.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const test = require('tape');
+const nock = require('nock');
+
+const openshiftRestClient = require('../');
+const openshiftConfigLoader = require('openshift-config-loader');
+const privates = require('../lib/private-map');
+
+test('find - projectrequests - basic findAll', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.projectrequests.findAll, 'function', 'There is a findAll method on the projectrequests object');
+
+      const clientConfig = privates.get(client).config;
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .get(`/oapi/v1/projectrequests`)
+        .reply(200, {kind: 'ProjectRequestList'});
+
+      const findResult = client.projectrequests.findAll().then((projectRequestList) => {
+        t.equal(projectRequestList.kind, 'ProjectRequestList', 'returns an object with ProjectRequestList');
+        t.end();
+      });
+
+      t.equal(findResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('create - projectrequest', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.projectrequests.create, 'function', 'There is a create method on the projectrequests object');
+
+      const clientConfig = privates.get(client).config;
+      const projectrequest = {
+        kind: 'ProjectRequest'
+      };
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .post(`/oapi/v1/projectrequests`)
+        .reply(200, {kind: 'ProjectRequest'});
+
+      const createResult = client.projectrequests.create(projectrequest).then((projectrequest) => {
+        t.equal(projectrequest.kind, 'ProjectRequest', 'returns an object with ProjectRequest');
+        t.end();
+      });
+
+      t.equal(createResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});

--- a/test/projects-test.js
+++ b/test/projects-test.js
@@ -22,7 +22,7 @@ test('testing project endpoint', (t) => {
         .get('/oapi/v1/projects')
         .reply(200, {mocked: 'mocked'});
 
-      client.projects.find().then((projects) => {
+      client.projects.findAll().then((projects) => {
         t.pass('return successful');
         t.end();
       });

--- a/test/projects-test.js
+++ b/test/projects-test.js
@@ -1,29 +1,201 @@
 'use strict';
 
-const openshiftRestClient = require('../');
-
 const test = require('tape');
 const nock = require('nock');
 
-const privates = require('../lib/private-map');
+const openshiftRestClient = require('../');
 const openshiftConfigLoader = require('openshift-config-loader');
+const privates = require('../lib/private-map');
 
-test('testing project endpoint', (t) => {
+test('find - projects - basic findAll', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
   };
 
   openshiftConfigLoader(settings).then((config) => {
     openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.projects.findAll, 'function', 'There is a findAll method on the projects object');
+
       const clientConfig = privates.get(client).config;
 
       nock(clientConfig.cluster)
         .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
-        .get('/oapi/v1/projects')
-        .reply(200, {mocked: 'mocked'});
+        .get(`/oapi/v1/projects`)
+        .reply(200, {kind: 'ProjectList'});
 
-      client.projects.findAll().then((projects) => {
-        t.pass('return successful');
+      const findResult = client.projects.findAll().then((projectList) => {
+        t.equal(projectList.kind, 'ProjectList', 'returns an object with ProjectList');
+        t.end();
+      });
+
+      t.equal(findResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('find - projects - basic find', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.projects.find, 'function', 'There is a find method on the projects object');
+
+      const clientConfig = privates.get(client).config;
+      const projectName = 'cool-project-name-1';
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .get(`/oapi/v1/projects/${projectName}`)
+        .reply(200, {kind: 'Project'});
+
+      const findResult = client.projects.find(projectName).then((project) => {
+        t.equal(project.kind, 'Project', 'returns an object with Project');
+        t.end();
+      });
+
+      t.equal(findResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('find - projects - find - no project name', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      client.projects.find().catch((err) => {
+        t.equal(err.message, 'Project Name is required', 'error message should return');
+        t.end();
+      });
+    });
+  });
+});
+
+test('create - project', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.projects.create, 'function', 'There is a create method on the projects object');
+
+      const clientConfig = privates.get(client).config;
+      const project = {
+        kind: 'Project'
+      };
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .post(`/oapi/v1/projects`)
+        .reply(200, {kind: 'Project'});
+
+      const createResult = client.projects.create(project).then((project) => {
+        t.equal(project.kind, 'Project', 'returns an object with Project');
+        t.end();
+      });
+
+      t.equal(createResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('update - project', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.projects.create, 'function', 'There is a create method on the projects object');
+
+      const clientConfig = privates.get(client).config;
+      const project = {
+        kind: 'Project'
+      };
+      const projectName = 'cool-project-name-1';
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .put(`/oapi/v1/projects/${projectName}`)
+        .reply(200, {kind: 'Project'});
+
+      const createResult = client.projects.update(projectName, project).then((project) => {
+        t.equal(project.kind, 'Project', 'returns an object with Project');
+        t.end();
+      });
+
+      t.equal(createResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('remove - projects - basic removeAll', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.projects.removeAll, 'function', 'There is a removeAll method on the projects object');
+
+      const clientConfig = privates.get(client).config;
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .delete(`/oapi/v1/projects`)
+        .reply(200, {kind: 'Status'});
+
+      const removeResult = client.projects.removeAll().then((projectList) => {
+        t.equal(projectList.kind, 'Status', 'returns an object with Status');
+        t.end();
+      });
+
+      t.equal(removeResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('remove - projects - basic remove', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.projects.remove, 'function', 'There is a remove method on the projects object');
+
+      const clientConfig = privates.get(client).config;
+      const projectName = 'cool-project-name-1';
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .delete(`/oapi/v1/projects/${projectName}`)
+        .reply(200, {kind: 'Status'});
+
+      const removeResult = client.projects.remove(projectName).then((status) => {
+        t.equal(status.kind, 'Status', 'returns an object with Status');
+        t.end();
+      });
+
+      t.equal(removeResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('remove - projects - remove - no project name', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      client.projects.remove().catch((err) => {
+        t.equal(err.message, 'Project Name is required', 'error message should return');
         t.end();
       });
     });

--- a/test/projects-test.js
+++ b/test/projects-test.js
@@ -134,6 +134,21 @@ test('update - project', (t) => {
   });
 });
 
+test('update - projects - update - no project name', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      client.projects.update().catch((err) => {
+        t.equal(err.message, 'Project Name is required', 'error message should return');
+        t.end();
+      });
+    });
+  });
+});
+
 test('remove - projects - basic removeAll', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`

--- a/test/replication-controllers-test.js
+++ b/test/replication-controllers-test.js
@@ -134,6 +134,21 @@ test('update - replicationcontroller', (t) => {
   });
 });
 
+test('update - replicationcontrollers - update - no replicationcontroller name', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      client.replicationcontrollers.update().catch((err) => {
+        t.equal(err.message, 'Replication Controller Name is required', 'error message should return');
+        t.end();
+      });
+    });
+  });
+});
+
 test('remove - replicationcontrollers - basic removeAll', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`

--- a/test/replication-controllers-test.js
+++ b/test/replication-controllers-test.js
@@ -7,7 +7,7 @@ const openshiftRestClient = require('../');
 const openshiftConfigLoader = require('openshift-config-loader');
 const privates = require('../lib/private-map');
 
-test('find - replication-controller - basic findAll', (t) => {
+test('find - replicationcontrollers - basic findAll', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
   };
@@ -23,8 +23,8 @@ test('find - replication-controller - basic findAll', (t) => {
         .get(`/api/v1/namespaces/${clientConfig.context.namespace}/replicationcontrollers`)
         .reply(200, {kind: 'ReplicationControllerList'});
 
-      const findResult = client.replicationcontrollers.findAll().then((replicationControllersList) => {
-        t.equal(replicationControllersList.kind, 'ReplicationControllerList', 'returns an object with ReplicationControllerList');
+      const findResult = client.replicationcontrollers.findAll().then((replicationControllerList) => {
+        t.equal(replicationControllerList.kind, 'ReplicationControllerList', 'returns an object with ReplicationControllerList');
         t.end();
       });
 
@@ -33,7 +33,7 @@ test('find - replication-controller - basic findAll', (t) => {
   });
 });
 
-test('find - replication-controller - basic find', (t) => {
+test('find - replicationcontrollers - basic find', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
   };
@@ -43,15 +43,15 @@ test('find - replication-controller - basic find', (t) => {
       t.equal(typeof client.replicationcontrollers.find, 'function', 'There is a find method on the replicationcontrollers object');
 
       const clientConfig = privates.get(client).config;
-      const replicationControllerName = 'cool-deployment-name-1';
+      const replicationControllerName = 'cool-replicationcontroller-name-1';
 
       nock(clientConfig.cluster)
         .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
         .get(`/api/v1/namespaces/${clientConfig.context.namespace}/replicationcontrollers/${replicationControllerName}`)
         .reply(200, {kind: 'ReplicationController'});
 
-      const findResult = client.replicationcontrollers.find(replicationControllerName).then((replicationController) => {
-        t.equal(replicationController.kind, 'ReplicationController', 'returns an object with ReplicationController');
+      const findResult = client.replicationcontrollers.find(replicationControllerName).then((replicationcontroller) => {
+        t.equal(replicationcontroller.kind, 'ReplicationController', 'returns an object with ReplicationController');
         t.end();
       });
 
@@ -60,7 +60,7 @@ test('find - replication-controller - basic find', (t) => {
   });
 });
 
-test('find - replication-controller - find - no rep name', (t) => {
+test('find - replicationcontrollers - find - no replicationcontroller name', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
   };
@@ -75,7 +75,66 @@ test('find - replication-controller - find - no rep name', (t) => {
   });
 });
 
-test('remove - replication-controller - basic removeAll', (t) => {
+test('create - replicationcontroller', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.replicationcontrollers.create, 'function', 'There is a create method on the replicationcontrollers object');
+
+      const clientConfig = privates.get(client).config;
+      const replicationcontroller = {
+        kind: 'ReplicationController'
+      };
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .post(`/api/v1/namespaces/${clientConfig.context.namespace}/replicationcontrollers`)
+        .reply(200, {kind: 'ReplicationController'});
+
+      const createResult = client.replicationcontrollers.create(replicationcontroller).then((replicationcontroller) => {
+        t.equal(replicationcontroller.kind, 'ReplicationController', 'returns an object with ReplicationController');
+        t.end();
+      });
+
+      t.equal(createResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('update - replicationcontroller', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.replicationcontrollers.create, 'function', 'There is a create method on the replicationcontrollers object');
+
+      const clientConfig = privates.get(client).config;
+      const replicationcontroller = {
+        kind: 'ReplicationController'
+      };
+      const replicationControllerName = 'cool-replicationcontroller-name-1';
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .put(`/api/v1/namespaces/${clientConfig.context.namespace}/replicationcontrollers/${replicationControllerName}`)
+        .reply(200, {kind: 'ReplicationController'});
+
+      const createResult = client.replicationcontrollers.update(replicationControllerName, replicationcontroller).then((replicationcontroller) => {
+        t.equal(replicationcontroller.kind, 'ReplicationController', 'returns an object with ReplicationController');
+        t.end();
+      });
+
+      t.equal(createResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('remove - replicationcontrollers - basic removeAll', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
   };
@@ -89,12 +148,10 @@ test('remove - replication-controller - basic removeAll', (t) => {
       nock(clientConfig.cluster)
         .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
         .delete(`/api/v1/namespaces/${clientConfig.context.namespace}/replicationcontrollers`)
-        .reply(200, {kind: 'ReplicationControllerList'});
+        .reply(200, {kind: 'Status'});
 
-      // Note: https://docs.openshift.org/latest/rest_api/kubernetes_v1.html#delete-collection-of-replicationcontroller says it return a Status object
-      // but it really returns a ReplicationControllerList object,  possible doc error?
-      const removeResult = client.replicationcontrollers.removeAll().then((replicationControllersList) => {
-        t.equal(replicationControllersList.kind, 'ReplicationControllerList', 'returns an object with ReplicationControllerList');
+      const removeResult = client.replicationcontrollers.removeAll().then((replicationControllerList) => {
+        t.equal(replicationControllerList.kind, 'Status', 'returns an object with Status');
         t.end();
       });
 
@@ -103,7 +160,7 @@ test('remove - replication-controller - basic removeAll', (t) => {
   });
 });
 
-test('remove - replication-controller - basic remove', (t) => {
+test('remove - replicationcontrollers - basic remove', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
   };
@@ -113,7 +170,7 @@ test('remove - replication-controller - basic remove', (t) => {
       t.equal(typeof client.replicationcontrollers.remove, 'function', 'There is a remove method on the replicationcontrollers object');
 
       const clientConfig = privates.get(client).config;
-      const replicationControllerName = 'cool-deployment-name-1';
+      const replicationControllerName = 'cool-replicationcontroller-name-1';
 
       nock(clientConfig.cluster)
         .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
@@ -130,7 +187,7 @@ test('remove - replication-controller - basic remove', (t) => {
   });
 });
 
-test('remove - replication-controller - remove - no rep name', (t) => {
+test('remove - replicationcontrollers - remove - no replicationcontroller name', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
   };

--- a/test/role-binding-test.js
+++ b/test/role-binding-test.js
@@ -1,0 +1,203 @@
+'use strict';
+
+const test = require('tape');
+const nock = require('nock');
+
+const openshiftRestClient = require('../');
+const openshiftConfigLoader = require('openshift-config-loader');
+const privates = require('../lib/private-map');
+
+test('find - rolebindings - basic findAll', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.rolebindings.findAll, 'function', 'There is a findAll method on the rolebindings object');
+
+      const clientConfig = privates.get(client).config;
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .get(`/oapi/v1/namespaces/${clientConfig.context.namespace}/rolebindings`)
+        .reply(200, {kind: 'RoleBindingList'});
+
+      const findResult = client.rolebindings.findAll().then((roleBindingList) => {
+        t.equal(roleBindingList.kind, 'RoleBindingList', 'returns an object with RoleBindingList');
+        t.end();
+      });
+
+      t.equal(findResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('find - rolebindings - basic find', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.rolebindings.find, 'function', 'There is a find method on the rolebindings object');
+
+      const clientConfig = privates.get(client).config;
+      const roleBindingName = 'cool-rolebinding-name-1';
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .get(`/oapi/v1/namespaces/${clientConfig.context.namespace}/rolebindings/${roleBindingName}`)
+        .reply(200, {kind: 'RoleBinding'});
+
+      const findResult = client.rolebindings.find(roleBindingName).then((rolebinding) => {
+        t.equal(rolebinding.kind, 'RoleBinding', 'returns an object with RoleBinding');
+        t.end();
+      });
+
+      t.equal(findResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('find - rolebindings - find - no rolebinding name', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      client.rolebindings.find().catch((err) => {
+        t.equal(err.message, 'Role Binding Name is required', 'error message should return');
+        t.end();
+      });
+    });
+  });
+});
+
+test('create - rolebinding', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.rolebindings.create, 'function', 'There is a create method on the rolebindings object');
+
+      const clientConfig = privates.get(client).config;
+      const rolebinding = {
+        kind: 'RoleBinding'
+      };
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .post(`/oapi/v1/namespaces/${clientConfig.context.namespace}/rolebindings`)
+        .reply(200, {kind: 'RoleBinding'});
+
+      const createResult = client.rolebindings.create(rolebinding).then((rolebinding) => {
+        t.equal(rolebinding.kind, 'RoleBinding', 'returns an object with RoleBinding');
+        t.end();
+      });
+
+      t.equal(createResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('update - rolebinding', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.rolebindings.create, 'function', 'There is a create method on the rolebindings object');
+
+      const clientConfig = privates.get(client).config;
+      const rolebinding = {
+        kind: 'RoleBinding'
+      };
+      const roleBindingName = 'cool-rolebinding-name-1';
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .put(`/oapi/v1/namespaces/${clientConfig.context.namespace}/rolebindings/${roleBindingName}`)
+        .reply(200, {kind: 'RoleBinding'});
+
+      const createResult = client.rolebindings.update(roleBindingName, rolebinding).then((rolebinding) => {
+        t.equal(rolebinding.kind, 'RoleBinding', 'returns an object with RoleBinding');
+        t.end();
+      });
+
+      t.equal(createResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('remove - rolebindings - basic removeAll', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.rolebindings.removeAll, 'function', 'There is a removeAll method on the rolebindings object');
+
+      const clientConfig = privates.get(client).config;
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .delete(`/oapi/v1/namespaces/${clientConfig.context.namespace}/rolebindings`)
+        .reply(200, {kind: 'Status'});
+
+      const removeResult = client.rolebindings.removeAll().then((roleBindingList) => {
+        t.equal(roleBindingList.kind, 'Status', 'returns an object with Status');
+        t.end();
+      });
+
+      t.equal(removeResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('remove - rolebindings - basic remove', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.rolebindings.remove, 'function', 'There is a remove method on the rolebindings object');
+
+      const clientConfig = privates.get(client).config;
+      const roleBindingName = 'cool-rolebinding-name-1';
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .delete(`/oapi/v1/namespaces/${clientConfig.context.namespace}/rolebindings/${roleBindingName}`)
+        .reply(200, {kind: 'Status'});
+
+      const removeResult = client.rolebindings.remove(roleBindingName).then((status) => {
+        t.equal(status.kind, 'Status', 'returns an object with Status');
+        t.end();
+      });
+
+      t.equal(removeResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('remove - rolebindings - remove - no rolebinding name', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      client.rolebindings.remove().catch((err) => {
+        t.equal(err.message, 'Role Binding Name is required', 'error message should return');
+        t.end();
+      });
+    });
+  });
+});

--- a/test/role-binding-test.js
+++ b/test/role-binding-test.js
@@ -134,6 +134,21 @@ test('update - rolebinding', (t) => {
   });
 });
 
+test('update - rolebindings - update - no rolebinding name', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      client.rolebindings.update().catch((err) => {
+        t.equal(err.message, 'Role Binding Name is required', 'error message should return');
+        t.end();
+      });
+    });
+  });
+});
+
 test('remove - rolebindings - basic removeAll', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`

--- a/test/routes-test.js
+++ b/test/routes-test.js
@@ -134,6 +134,21 @@ test('update - route', (t) => {
   });
 });
 
+test('update - routes - update - no route name', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      client.routes.update().catch((err) => {
+        t.equal(err.message, 'Route Name is required', 'error message should return');
+        t.end();
+      });
+    });
+  });
+});
+
 test('remove - routes - basic removeAll', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`

--- a/test/secrets-test.js
+++ b/test/secrets-test.js
@@ -134,6 +134,21 @@ test('update - secret', (t) => {
   });
 });
 
+test('update - secrets - update - no secret name', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      client.secrets.update().catch((err) => {
+        t.equal(err.message, 'Secret Name is required', 'error message should return');
+        t.end();
+      });
+    });
+  });
+});
+
 test('remove - secrets - basic removeAll', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`

--- a/test/services-test.js
+++ b/test/services-test.js
@@ -7,7 +7,33 @@ const openshiftRestClient = require('../');
 const openshiftConfigLoader = require('openshift-config-loader');
 const privates = require('../lib/private-map');
 
-test('find - services', (t) => {
+test('find - services - basic findAll', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.services.findAll, 'function', 'There is a findAll method on the services object');
+
+      const clientConfig = privates.get(client).config;
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .get(`/api/v1/namespaces/${clientConfig.context.namespace}/services`)
+        .reply(200, {kind: 'ServiceList'});
+
+      const findResult = client.services.findAll().then((serviceList) => {
+        t.equal(serviceList.kind, 'ServiceList', 'returns an object with ServiceList');
+        t.end();
+      });
+
+      t.equal(findResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('find - services - basic find', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
   };
@@ -17,14 +43,14 @@ test('find - services', (t) => {
       t.equal(typeof client.services.find, 'function', 'There is a find method on the services object');
 
       const clientConfig = privates.get(client).config;
-      const servicesName = 'nodejs-rest-http';
+      const serviceName = 'cool-service-name-1';
 
       nock(clientConfig.cluster)
         .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
-        .get(`/api/v1/namespaces/${clientConfig.context.namespace}/services/${servicesName}`)
+        .get(`/api/v1/namespaces/${clientConfig.context.namespace}/services/${serviceName}`)
         .reply(200, {kind: 'Service'});
 
-      const findResult = client.services.find(servicesName).then((service) => {
+      const findResult = client.services.find(serviceName).then((service) => {
         t.equal(service.kind, 'Service', 'returns an object with Service');
         t.end();
       });
@@ -34,7 +60,22 @@ test('find - services', (t) => {
   });
 });
 
-test('create - services', (t) => {
+test('find - services - find - no service name', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      client.services.find().catch((err) => {
+        t.equal(err.message, 'Service Name is required', 'error message should return');
+        t.end();
+      });
+    });
+  });
+});
+
+test('create - service', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
   };
@@ -63,6 +104,62 @@ test('create - services', (t) => {
   });
 });
 
+test('update - service', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.services.create, 'function', 'There is a create method on the services object');
+
+      const clientConfig = privates.get(client).config;
+      const service = {
+        kind: 'Service'
+      };
+      const serviceName = 'cool-service-name-1';
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .put(`/api/v1/namespaces/${clientConfig.context.namespace}/services/${serviceName}`)
+        .reply(200, {kind: 'Service'});
+
+      const createResult = client.services.update(serviceName, service).then((service) => {
+        t.equal(service.kind, 'Service', 'returns an object with Service');
+        t.end();
+      });
+
+      t.equal(createResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
+test('remove - services - basic removeAll', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      t.equal(typeof client.services.removeAll, 'function', 'There is a removeAll method on the services object');
+
+      const clientConfig = privates.get(client).config;
+
+      nock(clientConfig.cluster)
+        .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
+        .delete(`/api/v1/namespaces/${clientConfig.context.namespace}/services`)
+        .reply(200, {kind: 'Status'});
+
+      const removeResult = client.services.removeAll().then((serviceList) => {
+        t.equal(serviceList.kind, 'Status', 'returns an object with Status');
+        t.end();
+      });
+
+      t.equal(removeResult instanceof Promise, true, 'should return a Promise');
+    });
+  });
+});
+
 test('remove - services - basic remove', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
@@ -73,7 +170,7 @@ test('remove - services - basic remove', (t) => {
       t.equal(typeof client.services.remove, 'function', 'There is a remove method on the services object');
 
       const clientConfig = privates.get(client).config;
-      const serviceName = 'cool-service-name';
+      const serviceName = 'cool-service-name-1';
 
       nock(clientConfig.cluster)
         .matchHeader('authorization', `Bearer ${clientConfig.user.token}`) // taken from the config
@@ -90,7 +187,7 @@ test('remove - services - basic remove', (t) => {
   });
 });
 
-test('remove - services - remove - no rep name', (t) => {
+test('remove - services - remove - no service name', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`
   };

--- a/test/services-test.js
+++ b/test/services-test.js
@@ -134,6 +134,21 @@ test('update - service', (t) => {
   });
 });
 
+test('update - services - update - no service name', (t) => {
+  const settings = {
+    configLocation: `${__dirname}/test-config`
+  };
+
+  openshiftConfigLoader(settings).then((config) => {
+    openshiftRestClient(config).then((client) => {
+      client.services.update().catch((err) => {
+        t.equal(err.message, 'Service Name is required', 'error message should return');
+        t.end();
+      });
+    });
+  });
+});
+
 test('remove - services - basic removeAll', (t) => {
   const settings = {
     configLocation: `${__dirname}/test-config`


### PR DESCRIPTION
Hey there! We needed a good deal of resources & methods that weren't exposed by the library, and have added them. Hope this is useful!

## Build-configs
- Added findAll
- Updated find - added missing buildconfigname check
- Added update
- Added removeAll

## Builds
- Added findAll
- Updated find - added missing buildname check
- Added create
- Added update
- Added removeAll

## Cluster-role-bindings
- Full new findAll, find, create, remove

## ConfigMaps
- Added findAll
- Added create
- Added update
- Added remove
- Added removeAll

## DeploymentConfig
- Added findAll
- Updated find - added missing deploymentconfigname check
- Added update
- Added removeAll

## Groups
- Full new findAll, find, create, remove, removeAll

## ImageStreams
- Added findAll
- Updated find - added missing imagestreamname check
- Added update
- Added removeAll

## Pods
- Full new findAll, find, create, remove, removeAll

## ProjectRequests
- Full new findAll, create

## Projects
- *BREAKING CHANGE* find() was used for findAll-type, behaviour so has been renamed (have updated README.md to reflect this). The find() method now expects a project name, like all other resources.
- Added findAll
- Added create
- Added update
- Added remove
- Added removeAll

## Replication Controllers
- Added create
- Added update

## Role-bindings
- Full new findAll, find, create, remove, removeAll

## Routes
- Added findAll
- Updated find - added missing routename check
- Added update
- Added removeAll

## Secrets
- Added update

## Services
- Added findAll
- Updated find - added missing servicename check
- Added update
- Added removeAll